### PR TITLE
Ask before changing a user's Claude Code setting, and undo it exactly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,18 @@ name: CI
 
 on:
   push:
-    # Every branch, not only main: a branch push is the whole
-    # verification loop here — Windows only runs in CI, so fixes for it
-    # must be provable before they reach main, without needing a pull
-    # request as the trigger. The branch filter keeps tag pushes out;
-    # those already run these checks through the release workflow's
-    # call below.
-    branches: ["**"]
+    # main only: a push there is the record that the landed state was
+    # green, and the branch filter keeps tag pushes out — those run
+    # these checks through the release workflow's call below. Branches
+    # used to trigger on push too, but a branch with an open pull
+    # request then ran everything twice and the concurrency group
+    # cancelled one twin, leaving a failed run on every pull-request
+    # push. Branch verification without a pull request — a Windows fix
+    # proved before it reaches main, say — asks for it explicitly:
+    #   gh workflow run ci.yml --ref <branch>
+    branches: [main]
   pull_request:
+  workflow_dispatch:
   # Callable so the release workflow gates on these exact checks rather
   # than a second copy of them that can drift.
   workflow_call:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ All notable changes to trajector are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-08-31
+
+### Added
+
+- `trajector enable` asks about one optional Claude Code setting,
+  `showThinkingSummaries`. Claude Code stopped generating these
+  summaries by default in v2.1.89; turning the setting on shows you the
+  model's reasoning again, and makes contributed records carry it
+  instead of an empty field — which is why we ask. The question states,
+  on screen before you answer: which key changes and to what, what it
+  does for you, what it does for us, that it costs you nothing
+  (reasoning is generated and billed either way), that it reaches this
+  project only, how to undo it, and that declining changes nothing
+  else. Accepting has trajector write the project's own
+  `settings.local.json` and record what was there before; a value you
+  set yourself is stated, left alone, and never recorded; a value you
+  explicitly turned off elsewhere flips the suggested answer to no and
+  names the settings layer it came from. Without an interactive session
+  — a script, a pipeline — nothing is asked and nothing is written.
+- `trajector disable` and `trajector uninstall` put an accepted setting
+  back exactly as it was before trajector wrote it — the key deleted if
+  it was absent, an explicit `false` restored — unless you edited it
+  since: your later edit always wins. Declining ends the asking; the
+  choice stays visible in `trajector status`, and rerunning `enable` is
+  how you change your mind.
+- `trajector status` closes the project section with the setting's
+  state: a recommendation while it is off and never declined, one
+  factual line once declined, and "on" marked as trajector's write or
+  as your own. `doctor` says nothing about it — an optional setting
+  left off is not a fault.
+- `PRIVACY.md` publishes the rule all of this follows: what a setting
+  must satisfy before trajector may ask for it, how trajector may ask
+  (never blocking, one refusal ends it), what must be disclosed every
+  time, and the conditions under which `enable` may write a setting at
+  all.
+
+### Changed
+
+- The data agreement gains a clause covering these settings writes and
+  their exact undo, and its version is bumped. Recording pauses for
+  existing users until the new terms are reconfirmed with
+  `trajector enable`; forwarding is untouched.
+
 ## [0.2.0] - 2026-08-30
 
 ### Added
@@ -177,7 +220,8 @@ Hardened ahead of the tag:
 - State files are replaced and read atomically on every platform,
   Windows rename collisions included.
 
-[Unreleased]: https://github.com/PublicAI01/trajector-cli/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/PublicAI01/trajector-cli/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/PublicAI01/trajector-cli/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/PublicAI01/trajector-cli/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/PublicAI01/trajector-cli/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/PublicAI01/trajector-cli/releases/tag/v0.1.0

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -56,6 +56,85 @@ machine.** Known limitation: masking applies to values only — a secret
 placed in a JSON key position is not masked, because keys are structure
 and the pass never rewrites them.
 
+## Settings we ask you to change
+
+Some Claude Code settings make the data you contribute more complete, and so
+more valuable to us. That is our reason for asking, and we say so every time
+we ask.
+
+**By default we ask; we do not act.** trajector tells you what to change and
+leaves the change to you. What `trajector enable` asks you is the one
+exception, and it is described below.
+
+### What we may ask you to change
+
+A setting qualifies only if all six of these hold:
+
+1. **It costs you nothing.** Your token usage is identical with it on or off.
+2. **It does not degrade your own use of Claude Code.**
+3. **You can change it back yourself**, at any time, without us.
+4. **Its effect is visible to you** — not something only we can observe.
+5. **Declining costs you nothing.** Recording, compensation, and everything
+   trajector does are identical whether you accept or decline.
+6. **Its effect does not reach past what you already consented to.** A setting
+   that would change Claude Code's behaviour in projects you never enabled
+   does not qualify.
+
+A setting that fails any one of these is never asked for.
+
+### How we may ask
+
+- **Never blocking.** A recommendation appears only in the output of a command
+  you ran yourself, or as a session notice that does not interrupt you. There
+  is nothing you must answer in order to continue.
+- **One refusal ends it.** Decline an item and trajector stops bringing it up.
+  It stays listed in `trajector status`, where you can change your mind, and
+  appears nowhere else.
+
+### What we tell you, every time
+
+Before you decide, for each setting:
+
+- which key changes, and to what
+- what it does for you
+- what it does for us — why we want it
+- how far it reaches: this project only, or every project on this machine
+- how to undo it
+- what happens if you decline
+
+### The one exception: what `trajector enable` asks you
+
+`trajector enable` asks you about each qualifying setting and writes the ones
+you accept. This is the only place trajector writes a setting it does not need
+in order to function, and it is allowed only when all of these hold:
+
+- **the answer we suggest is yes — unless your own configuration already says
+  otherwise.** A setting you have explicitly turned off elsewhere is suggested
+  as no, and says what it is set to now, what accepting would change it to, and
+  that leaving it alone costs you nothing.
+- every setting states all six disclosures above, on screen, at the moment you
+  answer
+- **declining is as visible and as easy as accepting**, and the question cannot
+  go by without being seen
+- every setting stays visible and changeable afterwards in `trajector status`
+- **the change can be undone exactly** — restored to what it was before we
+  wrote it. A setting we cannot undo exactly is never asked about here, only
+  suggested for you to apply yourself.
+- **it is asked only where a person can answer.** With no interactive session —
+  a script, a pipeline, or any flag that answers for you — nothing is asked and
+  nothing is written, because none of the conditions above can be met when
+  nobody is reading.
+
+Nothing here fixes the shape of the question. A prompt, a list, or anything
+else is allowed as long as every condition holds; a shape that cannot meet one
+of them is not.
+
+### Settings added later
+
+When a later release adds a setting, you hear about it once through the
+non-blocking path above, whether or not you have already run `enable`. It
+follows the same rule: one refusal ends it.
+
 ## What leaves your machine
 
 Redacted records are packed into compressed batches (by default when 10 MiB

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Contributed data is sold to third-party buyers and contributors are
 compensated — that fact is public by design; what stays confidential is buyer
 identity and commercial terms, not the sale itself.
 
-**Status: early development. Not yet functional.**
+**Status: beta.** Functional end to end; interfaces and the data agreement
+may still change before 1.0.
 
 ## How it works
 

--- a/internal/claudesettings/claudesettings.go
+++ b/internal/claudesettings/claudesettings.go
@@ -6,6 +6,7 @@ package claudesettings
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -346,6 +347,11 @@ func parseSettings(path string, data []byte) (map[string]any, error) {
 	return root, nil
 }
 
+// errUnchanged, returned by a mutate callback, aborts an edit without
+// writing: the file the user formatted stays byte-for-byte as it is
+// instead of being re-marshalled.
+var errUnchanged = errors.New("claudesettings: no change")
+
 // edit is a read-modify-write of a file whose other writers are the
 // user and concurrent trajector processes; a plain last-write-wins
 // replacement would discard whatever a concurrent writer merged in, so
@@ -360,7 +366,7 @@ func edit(path string, mutate func(map[string]any) error) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	return fsatomic.Update(path, mode, func(old []byte) ([]byte, error) {
+	err := fsatomic.Update(path, mode, func(old []byte) ([]byte, error) {
 		root, err := parseSettings(path, old)
 		if err != nil {
 			return nil, err
@@ -374,4 +380,8 @@ func edit(path string, mutate func(map[string]any) error) error {
 		}
 		return append(data, '\n'), nil
 	})
+	if errors.Is(err, errUnchanged) {
+		return nil
+	}
+	return err
 }

--- a/internal/claudesettings/optional.go
+++ b/internal/claudesettings/optional.go
@@ -1,0 +1,55 @@
+package claudesettings
+
+// KeyShowThinkingSummaries is the Claude Code setting that controls
+// whether thinking summaries are shown to the user.
+const KeyShowThinkingSummaries = "showThinkingSummaries"
+
+// Disclosure is one labeled line of what the user is told before
+// deciding about an optional setting.
+type Disclosure struct {
+	Label string
+	Text  string
+}
+
+// OptionalSetting describes a Claude Code setting trajector may ask
+// the user to change. Every string is final wording: rendering may
+// re-wrap lines, never rewrite words — this text is the whole
+// disclosure the user gets, with nothing elsewhere to back it up.
+type OptionalSetting struct {
+	Key string
+	// Target is the value written when the user accepts.
+	Target      bool
+	Intro       string
+	Disclosures []Disclosure
+	// Fact is stated after the disclosures.
+	Fact string
+	// AlreadyOn is stated when the user already has the setting on
+	// themselves: what their own configuration already achieves.
+	AlreadyOn string
+}
+
+// OptionalSettings is the one truth source for the settings trajector
+// may ask about.
+var OptionalSettings = []OptionalSetting{{
+	Key:    KeyShowThinkingSummaries,
+	Target: true,
+	Intro: "Claude Code can show you a summary of the model's reasoning as it " +
+		"works. It is off by default, and turning it on also makes the " +
+		"records you contribute more complete.",
+	Disclosures: []Disclosure{
+		{"What changes", KeyShowThinkingSummaries + " becomes true in " + ProjectLocalRel},
+		{"For you", "you see the model's reasoning summarised as it works"},
+		{"For us", "your contributed records carry that reasoning instead of " +
+			"an empty field, which makes them more valuable to us"},
+		{"How far", "this project only; no other project on this machine is affected"},
+		{"Cost", "none. Reasoning is generated and billed either way — this " +
+			"only decides whether you are shown it"},
+		{"Undoing it", "`trajector disable` puts it back exactly as it was, or " +
+			"change it yourself at any time"},
+		{"If you say no", "nothing else changes. Recording, rewards, and every " +
+			"other part of trajector work the same"},
+	},
+	Fact: "Claude Code stopped generating these summaries by default in " +
+		"v2.1.89. This setting turns them back on.",
+	AlreadyOn: "Your contributed records already carry the model's reasoning.",
+}}

--- a/internal/claudesettings/toplevel.go
+++ b/internal/claudesettings/toplevel.go
@@ -1,0 +1,110 @@
+package claudesettings
+
+import "os"
+
+// SettingState classifies an optional setting's effective value across
+// the settings chain.
+type SettingState int
+
+const (
+	// Unset: no layer sets the key. Distinct from OffByUser — the
+	// behavior is the same, but "never said" and "explicitly turned
+	// off" get opposite suggested answers.
+	Unset SettingState = iota
+	// OnByUs: the project-local value is the true trajector wrote.
+	OnByUs
+	// OnByUser: an effective true trajector did not write.
+	OnByUser
+	// OffByUser: an explicit false, wherever it comes from.
+	OffByUser
+)
+
+// SettingStatus pairs the state with the layer the deciding value came
+// from. Source is meaningful only for OnByUser and OffByUser.
+type SettingStatus struct {
+	State  SettingState
+	Source Source
+}
+
+// ClassifySetting resolves a top-level boolean key the way Claude Code
+// does — project-local, then project, then user settings; top-level
+// keys have no shell layer — and classifies the outcome. A bare bool
+// carries no shape that could mark it as trajector's own writing, so
+// writtenByUs brings that fact in from the caller's records.
+func ClassifySetting(projectRoot, home, key string, writtenByUs bool) SettingStatus {
+	value, source, found := firstTopLevelBool(projectRoot, home, key)
+	switch {
+	case !found:
+		return SettingStatus{State: Unset}
+	case !value:
+		return SettingStatus{State: OffByUser, Source: source}
+	case source == SourceProjectLocal && writtenByUs:
+		return SettingStatus{State: OnByUs}
+	default:
+		return SettingStatus{State: OnByUser, Source: source}
+	}
+}
+
+func firstTopLevelBool(projectRoot, home, key string) (bool, Source, bool) {
+	chain := []struct {
+		path   string
+		source Source
+	}{
+		{ProjectLocalPath(projectRoot), SourceProjectLocal},
+		{projectSharedPath(projectRoot), SourceProject},
+		{UserSettingsPath(home), SourceUser},
+	}
+	for _, link := range chain {
+		if value, found := TopLevelBool(link.path, key); found {
+			return value, link.source, true
+		}
+	}
+	return false, "", false
+}
+
+// TopLevelBool reads a top-level boolean key from the settings file at
+// path. found separates an explicit false from an absent key; a
+// missing or unreadable file reads as absent, as does a value of any
+// other type.
+func TopLevelBool(path, key string) (value, found bool) {
+	root, err := readSettings(path)
+	if err != nil {
+		return false, false
+	}
+	value, found = root[key].(bool)
+	return value, found
+}
+
+// SetTopLevelBool writes value under the top-level key in the settings
+// file at path, preserving all other content.
+func SetTopLevelBool(path, key string, value bool) error {
+	return edit(path, func(root map[string]any) error {
+		root[key] = value
+		return nil
+	})
+}
+
+// RestoreTopLevelBool puts the top-level key back to its recorded
+// prior state: deleted when priorFound is false, priorValue written
+// back otherwise. It acts only while the key still holds wrote, the
+// value trajector set — anything else is a later hand edit, and the
+// user's most recent decision wins, so the file is left byte-for-byte
+// as it is. The check and the restore share one locked edit so no
+// concurrent writer can slip between them. A missing file stays
+// missing.
+func RestoreTopLevelBool(path, key string, wrote, priorValue, priorFound bool) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+	return edit(path, func(root map[string]any) error {
+		if current, ok := root[key].(bool); !ok || current != wrote {
+			return errUnchanged
+		}
+		if !priorFound {
+			delete(root, key)
+			return nil
+		}
+		root[key] = priorValue
+		return nil
+	})
+}

--- a/internal/claudesettings/toplevel_test.go
+++ b/internal/claudesettings/toplevel_test.go
@@ -1,0 +1,274 @@
+package claudesettings
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeFileAt(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClassifySetting_ChainPrecedenceDecidesStateAndSource(t *testing.T) {
+	tests := []struct {
+		name         string
+		projectLocal string
+		project      string
+		user         string
+		writtenByUs  bool
+		want         SettingStatus
+	}{
+		{
+			name: "nothing set anywhere",
+			want: SettingStatus{State: Unset},
+		},
+		{
+			name: "true in user settings",
+			user: `{"showThinkingSummaries": true}`,
+			want: SettingStatus{State: OnByUser, Source: SourceUser},
+		},
+		{
+			name:    "true in project settings beats false in user settings",
+			project: `{"showThinkingSummaries": true}`,
+			user:    `{"showThinkingSummaries": false}`,
+			want:    SettingStatus{State: OnByUser, Source: SourceProject},
+		},
+		{
+			name:         "false in project local beats true in project settings",
+			projectLocal: `{"showThinkingSummaries": false}`,
+			project:      `{"showThinkingSummaries": true}`,
+			want:         SettingStatus{State: OffByUser, Source: SourceProjectLocal},
+		},
+		{
+			name:         "project local true recorded as ours",
+			projectLocal: `{"showThinkingSummaries": true}`,
+			writtenByUs:  true,
+			want:         SettingStatus{State: OnByUs},
+		},
+		{
+			name:         "project local true not recorded as ours",
+			projectLocal: `{"showThinkingSummaries": true}`,
+			want:         SettingStatus{State: OnByUser, Source: SourceProjectLocal},
+		},
+		{
+			name:        "our record cannot claim a value in another layer",
+			user:        `{"showThinkingSummaries": true}`,
+			writtenByUs: true,
+			want:        SettingStatus{State: OnByUser, Source: SourceUser},
+		},
+		{
+			name:         "project local false recorded as ours is the user's later word",
+			projectLocal: `{"showThinkingSummaries": false}`,
+			writtenByUs:  true,
+			want:         SettingStatus{State: OffByUser, Source: SourceProjectLocal},
+		},
+		{
+			name:         "non-boolean value is skipped",
+			projectLocal: `{"showThinkingSummaries": "yes"}`,
+			user:         `{"showThinkingSummaries": true}`,
+			want:         SettingStatus{State: OnByUser, Source: SourceUser},
+		},
+		{
+			name:         "unreadable layer is skipped",
+			projectLocal: `{not json`,
+			user:         `{"showThinkingSummaries": false}`,
+			want:         SettingStatus{State: OffByUser, Source: SourceUser},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project, home := t.TempDir(), t.TempDir()
+			if tt.projectLocal != "" {
+				writeFileAt(t, ProjectLocalPath(project), tt.projectLocal)
+			}
+			if tt.project != "" {
+				writeFileAt(t, projectSharedPath(project), tt.project)
+			}
+			if tt.user != "" {
+				writeFileAt(t, UserSettingsPath(home), tt.user)
+			}
+			got := ClassifySetting(project, home, KeyShowThinkingSummaries, tt.writtenByUs)
+			if got != tt.want {
+				t.Errorf("ClassifySetting = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifySetting_ExplicitFalseIsNotUnset(t *testing.T) {
+	project, home := t.TempDir(), t.TempDir()
+	writeFileAt(t, UserSettingsPath(home), `{"other": true}`)
+	if got := ClassifySetting(project, home, KeyShowThinkingSummaries, false); got.State != Unset {
+		t.Errorf("absent key classified as %+v, want Unset", got)
+	}
+	writeFileAt(t, UserSettingsPath(home), `{"showThinkingSummaries": false}`)
+	want := SettingStatus{State: OffByUser, Source: SourceUser}
+	if got := ClassifySetting(project, home, KeyShowThinkingSummaries, false); got != want {
+		t.Errorf("explicit false classified as %+v, want %+v", got, want)
+	}
+}
+
+func TestTopLevelBool_SeparatesExplicitFalseFromAbsent(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantValue bool
+		wantFound bool
+	}{
+		{name: "missing file"},
+		{name: "empty object", content: `{}`},
+		{name: "key absent among other content", content: `{"env": {"A": "b"}}`},
+		{name: "explicit false", content: `{"showThinkingSummaries": false}`, wantFound: true},
+		{name: "explicit true", content: `{"showThinkingSummaries": true}`, wantValue: true, wantFound: true},
+		{name: "non-boolean value", content: `{"showThinkingSummaries": "true"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.local.json")
+			if tt.content != "" {
+				writeFileAt(t, path, tt.content)
+			}
+			value, found := TopLevelBool(path, KeyShowThinkingSummaries)
+			if value != tt.wantValue || found != tt.wantFound {
+				t.Errorf("TopLevelBool = %v, %v; want %v, %v", value, found, tt.wantValue, tt.wantFound)
+			}
+		})
+	}
+}
+
+func TestSetTopLevelBool_PreservesUserContent(t *testing.T) {
+	root := t.TempDir()
+	path := ProjectLocalPath(root)
+	writeFileAt(t, path, `{
+		"permissions": {"allow": ["Bash(npm test)"]},
+		"env": {"MY_VAR": "keep-me"},
+		"cleanupPeriodDays": 20
+	}`)
+
+	if err := SetTopLevelBool(path, KeyShowThinkingSummaries, true); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := readJSON(t, path)
+	if settings[KeyShowThinkingSummaries] != true {
+		t.Errorf("key = %v, want true", settings[KeyShowThinkingSummaries])
+	}
+	env, _ := settings["env"].(map[string]any)
+	if env["MY_VAR"] != "keep-me" {
+		t.Errorf("env = %v", settings["env"])
+	}
+	if _, ok := settings["permissions"]; !ok {
+		t.Error("permissions block lost")
+	}
+	if settings["cleanupPeriodDays"] != float64(20) {
+		t.Errorf("cleanupPeriodDays = %v, want kept", settings["cleanupPeriodDays"])
+	}
+}
+
+func TestSetThenRestore_AbsentKeyIsDeletedAgain(t *testing.T) {
+	root := t.TempDir()
+	path := ProjectLocalPath(root)
+	writeFileAt(t, path, `{"env": {"MY_VAR": "keep-me"}}`)
+	original := readJSON(t, path)
+
+	priorValue, priorFound := TopLevelBool(path, KeyShowThinkingSummaries)
+	if err := SetTopLevelBool(path, KeyShowThinkingSummaries, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := RestoreTopLevelBool(path, KeyShowThinkingSummaries, true, priorValue, priorFound); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readJSON(t, path); !reflect.DeepEqual(got, original) {
+		t.Errorf("settings after set+restore differ from original:\n%v", got)
+	}
+}
+
+func TestSetThenRestore_ExplicitFalseComesBack(t *testing.T) {
+	root := t.TempDir()
+	path := ProjectLocalPath(root)
+	writeFileAt(t, path, `{"showThinkingSummaries": false, "env": {"MY_VAR": "keep-me"}}`)
+	original := readJSON(t, path)
+
+	priorValue, priorFound := TopLevelBool(path, KeyShowThinkingSummaries)
+	if err := SetTopLevelBool(path, KeyShowThinkingSummaries, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := RestoreTopLevelBool(path, KeyShowThinkingSummaries, true, priorValue, priorFound); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readJSON(t, path); !reflect.DeepEqual(got, original) {
+		t.Errorf("settings after set+restore differ from original:\n%v", got)
+	}
+}
+
+func TestRestore_UserEditedValueIsLeftAlone(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		priorValue bool
+		priorFound bool
+	}{
+		{
+			name:    "flipped to false after our write, absent before",
+			content: `{"showThinkingSummaries": false}`,
+		},
+		{
+			name:    "key deleted after our write, absent before",
+			content: `{"env": {"MY_VAR": "keep-me"}}`,
+		},
+		{
+			name:       "put back to false by hand, false before",
+			content:    `{"showThinkingSummaries": false}`,
+			priorFound: true,
+		},
+		{
+			name:       "key deleted after our write, false before",
+			content:    `{"other": true}`,
+			priorFound: true,
+		},
+		{
+			name:    "replaced with a non-boolean after our write",
+			content: `{"showThinkingSummaries": "always"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.local.json")
+			writeFileAt(t, path, tt.content)
+
+			if err := RestoreTopLevelBool(path, KeyShowThinkingSummaries, true, tt.priorValue, tt.priorFound); err != nil {
+				t.Fatal(err)
+			}
+
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(after, []byte(tt.content)) {
+				t.Errorf("restore rewrote a file it had no claim on:\n%s", after)
+			}
+		})
+	}
+}
+
+func TestRestore_MissingFileIsLeftMissing(t *testing.T) {
+	root := t.TempDir()
+	path := ProjectLocalPath(root)
+	if err := RestoreTopLevelBool(path, KeyShowThinkingSummaries, true, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("restore created %s", path)
+	}
+}

--- a/internal/consent/agreement.go
+++ b/internal/consent/agreement.go
@@ -3,7 +3,7 @@ package consent
 // AgreementVersion identifies the agreement text below. Bumping it
 // makes every earlier acceptance stale: capture pauses until the user
 // reconfirms, so recorded consent always matches the current terms.
-const AgreementVersion = "2026-08-07"
+const AgreementVersion = "2026-08-31"
 
 // AgreementText is shown in full before the explicit yes/no prompt.
 // It states the actual client behavior and must be kept truthful to
@@ -33,7 +33,13 @@ machine.
    non-official base URL, its records are marked as third-party
    origin. Reward terms are the same regardless of origin.
 
-5. Revocation. Disabling a project stops collection immediately,
+5. Optional client settings. During enable, trajector may offer an
+   optional Claude Code setting. If you accept, trajector writes that
+   setting to the project's local Claude Code configuration, records
+   what was there before, and restores it exactly when you disable
+   the project or uninstall. If you decline, nothing else changes.
+
+6. Revocation. Disabling a project stops collection immediately,
    revokes its token, and deletes its local unuploaded data. You may
    additionally request deletion of uploaded data that has not yet
    been delivered. Data already delivered and rewarded is covered by

--- a/internal/consent/consent.go
+++ b/internal/consent/consent.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 
 	"github.com/PublicAI01/trajector-cli/internal/fsatomic"
@@ -43,6 +44,9 @@ type projectRecord struct {
 	RootPath  string       `json:"root_path"`
 	State     ProjectState `json:"state"`
 	UpdatedAt string       `json:"updated_at"`
+	// Settings is absent in store files written before optional
+	// settings existed; both readers treat absence as "no decisions".
+	Settings map[string]SettingDecision `json:"settings,omitempty"`
 }
 
 // Store reads and writes the consent file. Every method loads the
@@ -88,13 +92,16 @@ func (s *Store) ProjectState(projectIDHash string) (ProjectState, bool, error) {
 	return rec.State, ok, nil
 }
 
-// SetProjectState records a project's decision.
+// SetProjectState records a project's decision. Setting decisions are
+// kept: a declined answer must survive disable/enable cycles so one
+// refusal keeps ending the ask.
 func (s *Store) SetProjectState(projectIDHash, rootPath string, state ProjectState, at string) error {
 	return s.update(func(f *storeFile) {
 		f.Projects[projectIDHash] = projectRecord{
 			RootPath:  rootPath,
 			State:     state,
 			UpdatedAt: at,
+			Settings:  f.Projects[projectIDHash].Settings,
 		}
 	})
 }
@@ -140,7 +147,7 @@ func (s *Store) RestoreProject(snap ProjectSnapshot) error {
 		if !ok && snap.rec == nil {
 			return nil
 		}
-		if ok && snap.rec != nil && rec == *snap.rec {
+		if ok && snap.rec != nil && reflect.DeepEqual(rec, *snap.rec) {
 			return nil
 		}
 	}

--- a/internal/consent/setting.go
+++ b/internal/consent/setting.go
@@ -1,0 +1,114 @@
+package consent
+
+import "fmt"
+
+// SettingAnswer is the user's recorded answer to an optional Claude
+// Code setting offered during enable.
+type SettingAnswer string
+
+const (
+	AnswerAccepted SettingAnswer = "accepted"
+	AnswerDeclined SettingAnswer = "declined"
+)
+
+// SettingPrior is what the project's configuration held before an
+// accepted setting was applied. PriorTrue means the value was already
+// true and nothing was written, so disable must leave it alone; only
+// PriorAbsent and PriorFalse mark a write of ours to undo. Merging
+// these states would make disable delete a value the user set.
+type SettingPrior string
+
+const (
+	PriorAbsent SettingPrior = "absent"
+	PriorFalse  SettingPrior = "false"
+	PriorTrue   SettingPrior = "true"
+)
+
+// SettingDecision is one setting's recorded answer.
+type SettingDecision struct {
+	Answer SettingAnswer `json:"answer"`
+	// Prior is set exactly when the answer is accepted.
+	Prior     SettingPrior `json:"prior,omitempty"`
+	DecidedAt string       `json:"decided_at"`
+}
+
+// SetSettingDecision records the user's answer for one optional
+// setting. The project must already have a recorded decision; a
+// setting answer without one has no enable to belong to.
+func (s *Store) SetSettingDecision(projectIDHash, settingKey string, d SettingDecision) error {
+	if projectIDHash == "" {
+		return fmt.Errorf("consent: project hash is required")
+	}
+	if settingKey == "" {
+		return fmt.Errorf("consent: setting key is required")
+	}
+	switch d.Answer {
+	case AnswerAccepted:
+		switch d.Prior {
+		case PriorAbsent, PriorFalse, PriorTrue:
+		default:
+			return fmt.Errorf("consent: accepted setting decision needs a prior state, got %q", d.Prior)
+		}
+	case AnswerDeclined:
+		if d.Prior != "" {
+			return fmt.Errorf("consent: declined setting decision cannot carry a prior state")
+		}
+	default:
+		return fmt.Errorf("consent: unknown setting answer %q", d.Answer)
+	}
+	var missing bool
+	err := s.update(func(f *storeFile) {
+		rec, ok := f.Projects[projectIDHash]
+		if !ok {
+			missing = true
+			return
+		}
+		if rec.Settings == nil {
+			rec.Settings = map[string]SettingDecision{}
+		}
+		rec.Settings[settingKey] = d
+		f.Projects[projectIDHash] = rec
+	})
+	if err != nil {
+		return err
+	}
+	if missing {
+		return fmt.Errorf("consent: no project record to attach a setting decision to")
+	}
+	return nil
+}
+
+// SettingDecisions reports a project's recorded setting decisions by
+// setting key; a project with none yields an empty map.
+func (s *Store) SettingDecisions(projectIDHash string) (map[string]SettingDecision, error) {
+	f, err := s.read()
+	if err != nil {
+		return nil, err
+	}
+	return f.Projects[projectIDHash].Settings, nil
+}
+
+// ClearSettingDecision removes one setting's recorded decision,
+// leaving the project's state and its other decisions in place.
+// Call it only after the setting was successfully restored: the
+// record is the only way left to undo the write, so a failed restore
+// must never clear. Unknown projects and settings are a no-op.
+func (s *Store) ClearSettingDecision(projectIDHash, settingKey string) error {
+	if projectIDHash == "" {
+		return fmt.Errorf("consent: project hash is required")
+	}
+	if settingKey == "" {
+		return fmt.Errorf("consent: setting key is required")
+	}
+	return s.update(func(f *storeFile) {
+		rec, ok := f.Projects[projectIDHash]
+		if !ok {
+			return
+		}
+		delete(rec.Settings, settingKey)
+		if len(rec.Settings) == 0 {
+			rec.Settings = nil
+		}
+		f.Projects[projectIDHash] = rec
+	})
+}

--- a/internal/consent/setting_test.go
+++ b/internal/consent/setting_test.go
@@ -1,0 +1,263 @@
+package consent_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/PublicAI01/trajector-cli/internal/consent"
+)
+
+func grantProject(t *testing.T, s *consent.Store, hash string) {
+	t.Helper()
+	if err := s.SetProjectState(hash, "/project/p", consent.StateGranted, "2026-08-31T10:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSettingDecisionRoundTripsEachAnswerShape(t *testing.T) {
+	cases := []struct {
+		name     string
+		decision consent.SettingDecision
+	}{
+		{"declined", consent.SettingDecision{
+			Answer:    consent.AnswerDeclined,
+			DecidedAt: "2026-08-31T10:01:00Z",
+		}},
+		{"accepted with nothing written because the value was already true", consent.SettingDecision{
+			Answer:    consent.AnswerAccepted,
+			Prior:     consent.PriorTrue,
+			DecidedAt: "2026-08-31T10:02:00Z",
+		}},
+		{"accepted and written over an absent key", consent.SettingDecision{
+			Answer:    consent.AnswerAccepted,
+			Prior:     consent.PriorAbsent,
+			DecidedAt: "2026-08-31T10:03:00Z",
+		}},
+		{"accepted and written over an explicit false", consent.SettingDecision{
+			Answer:    consent.AnswerAccepted,
+			Prior:     consent.PriorFalse,
+			DecidedAt: "2026-08-31T10:04:00Z",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := open(t)
+			grantProject(t, s, "hash-p")
+			if err := s.SetSettingDecision("hash-p", "showThinkingSummaries", tc.decision); err != nil {
+				t.Fatal(err)
+			}
+			reopened := consent.Open(s.Path())
+			decisions, err := reopened.SettingDecisions("hash-p")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := decisions["showThinkingSummaries"]; got != tc.decision {
+				t.Errorf("round-tripped decision = %+v, want %+v", got, tc.decision)
+			}
+			if len(decisions) != 1 {
+				t.Errorf("decisions = %+v, want exactly one", decisions)
+			}
+		})
+	}
+}
+
+func TestSettingDecisionRejectsMalformedShapes(t *testing.T) {
+	cases := []struct {
+		name      string
+		hash, key string
+		decision  consent.SettingDecision
+	}{
+		{"accepted without a prior state", "hash-p", "showThinkingSummaries",
+			consent.SettingDecision{Answer: consent.AnswerAccepted, DecidedAt: "2026-08-31T10:00:00Z"}},
+		{"accepted with an unknown prior state", "hash-p", "showThinkingSummaries",
+			consent.SettingDecision{Answer: consent.AnswerAccepted, Prior: "maybe", DecidedAt: "2026-08-31T10:00:00Z"}},
+		{"declined carrying a prior state", "hash-p", "showThinkingSummaries",
+			consent.SettingDecision{Answer: consent.AnswerDeclined, Prior: consent.PriorAbsent, DecidedAt: "2026-08-31T10:00:00Z"}},
+		{"unknown answer", "hash-p", "showThinkingSummaries",
+			consent.SettingDecision{Answer: "shrugged", DecidedAt: "2026-08-31T10:00:00Z"}},
+		{"empty answer", "hash-p", "showThinkingSummaries",
+			consent.SettingDecision{DecidedAt: "2026-08-31T10:00:00Z"}},
+		{"empty setting key", "hash-p", "",
+			consent.SettingDecision{Answer: consent.AnswerDeclined, DecidedAt: "2026-08-31T10:00:00Z"}},
+		{"empty project hash", "", "showThinkingSummaries",
+			consent.SettingDecision{Answer: consent.AnswerDeclined, DecidedAt: "2026-08-31T10:00:00Z"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := open(t)
+			grantProject(t, s, "hash-p")
+			if err := s.SetSettingDecision(tc.hash, tc.key, tc.decision); err == nil {
+				t.Error("malformed decision was recorded")
+			}
+			decisions, err := s.SettingDecisions("hash-p")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(decisions) != 0 {
+				t.Errorf("store holds %+v after a rejected decision", decisions)
+			}
+		})
+	}
+}
+
+func TestSettingDecisionNeedsARecordedProject(t *testing.T) {
+	s := open(t)
+	err := s.SetSettingDecision("hash-unknown", "showThinkingSummaries", consent.SettingDecision{
+		Answer:    consent.AnswerDeclined,
+		DecidedAt: "2026-08-31T10:00:00Z",
+	})
+	if err == nil {
+		t.Error("decision for an unrecorded project was accepted")
+	}
+	if _, ok, err := s.ProjectState("hash-unknown"); err != nil || ok {
+		t.Errorf("a project record appeared: ok = %v, err = %v", ok, err)
+	}
+}
+
+func TestStoreWrittenBeforeSettingDecisionsStillWorks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "consent-under-test.json")
+	old := `{
+  "agreement": {"version": "2026-08-07", "accepted_at": "2026-08-07T00:00:00Z"},
+  "projects": {
+    "hash-old": {"root_path": "/project/old", "state": "granted", "updated_at": "2026-08-07T00:00:01Z"}
+  }
+}`
+	if err := os.WriteFile(path, []byte(old), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := consent.Open(path)
+
+	version, at, err := s.AcceptedVersion()
+	if err != nil || version != "2026-08-07" || at != "2026-08-07T00:00:00Z" {
+		t.Errorf("AcceptedVersion = %q, %q, %v", version, at, err)
+	}
+	if state, ok, err := s.ProjectState("hash-old"); err != nil || !ok || state != consent.StateGranted {
+		t.Errorf("ProjectState = %q, %v, %v", state, ok, err)
+	}
+	decisions, err := s.SettingDecisions("hash-old")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != 0 {
+		t.Errorf("decisions on an old-format store = %+v, want none", decisions)
+	}
+
+	if err := s.SetSettingDecision("hash-old", "showThinkingSummaries", consent.SettingDecision{
+		Answer:    consent.AnswerAccepted,
+		Prior:     consent.PriorAbsent,
+		DecidedAt: "2026-08-31T10:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if state, ok, err := s.ProjectState("hash-old"); err != nil || !ok || state != consent.StateGranted {
+		t.Errorf("ProjectState after recording a decision = %q, %v, %v", state, ok, err)
+	}
+}
+
+func TestClearSettingDecisionLeavesTheRestOfTheProjectAlone(t *testing.T) {
+	s := open(t)
+	grantProject(t, s, "hash-p")
+	written := consent.SettingDecision{Answer: consent.AnswerAccepted, Prior: consent.PriorFalse, DecidedAt: "2026-08-31T10:01:00Z"}
+	declined := consent.SettingDecision{Answer: consent.AnswerDeclined, DecidedAt: "2026-08-31T10:02:00Z"}
+	if err := s.SetSettingDecision("hash-p", "showThinkingSummaries", written); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetSettingDecision("hash-p", "anotherOptionalKey", declined); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.ClearSettingDecision("hash-p", "showThinkingSummaries"); err != nil {
+		t.Fatal(err)
+	}
+
+	decisions, err := s.SettingDecisions("hash-p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := decisions["showThinkingSummaries"]; ok {
+		t.Error("cleared decision is still recorded")
+	}
+	if got := decisions["anotherOptionalKey"]; got != declined {
+		t.Errorf("the other decision changed: %+v", got)
+	}
+	if state, ok, err := s.ProjectState("hash-p"); err != nil || !ok || state != consent.StateGranted {
+		t.Errorf("project state after clear = %q, %v, %v", state, ok, err)
+	}
+}
+
+func TestClearSettingDecisionIsANoOpWhenNothingIsRecorded(t *testing.T) {
+	s := open(t)
+	if err := s.ClearSettingDecision("hash-unknown", "showThinkingSummaries"); err != nil {
+		t.Errorf("clearing on an unknown project failed: %v", err)
+	}
+	grantProject(t, s, "hash-p")
+	if err := s.ClearSettingDecision("hash-p", "showThinkingSummaries"); err != nil {
+		t.Errorf("clearing an unrecorded setting failed: %v", err)
+	}
+	if state, ok, err := s.ProjectState("hash-p"); err != nil || !ok || state != consent.StateGranted {
+		t.Errorf("project state after no-op clear = %q, %v, %v", state, ok, err)
+	}
+}
+
+func TestProjectStateChangeKeepsSettingDecisions(t *testing.T) {
+	s := open(t)
+	grantProject(t, s, "hash-p")
+	declined := consent.SettingDecision{Answer: consent.AnswerDeclined, DecidedAt: "2026-08-31T10:01:00Z"}
+	if err := s.SetSettingDecision("hash-p", "showThinkingSummaries", declined); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetProjectState("hash-p", "/project/p", consent.StateDenied, "2026-08-31T11:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	decisions, err := s.SettingDecisions("hash-p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := decisions["showThinkingSummaries"]; got != declined {
+		t.Errorf("decision after a state change = %+v, want %+v", got, declined)
+	}
+}
+
+func TestRestoreProjectRollsBackSettingDecisionsRecordedMeanwhile(t *testing.T) {
+	s := open(t)
+	grantProject(t, s, "hash-p")
+	snap, err := s.SnapshotProject("hash-p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetSettingDecision("hash-p", "showThinkingSummaries", consent.SettingDecision{
+		Answer:    consent.AnswerAccepted,
+		Prior:     consent.PriorAbsent,
+		DecidedAt: "2026-08-31T10:01:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RestoreProject(snap); err != nil {
+		t.Fatal(err)
+	}
+	decisions, err := s.SettingDecisions("hash-p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != 0 {
+		t.Errorf("decisions survived the rollback: %+v", decisions)
+	}
+	if state, ok, err := s.ProjectState("hash-p"); err != nil || !ok || state != consent.StateGranted {
+		t.Errorf("project state after rollback = %q, %v, %v", state, ok, err)
+	}
+}
+
+func TestAcceptanceOfAnEarlierAgreementVersionIsStale(t *testing.T) {
+	s := open(t)
+	if err := s.AcceptAgreement("2026-08-07", "2026-08-07T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	version, _, err := s.AcceptedVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version == consent.AgreementVersion {
+		t.Error("an earlier acceptance matches the current agreement version")
+	}
+}

--- a/internal/lifecycle/diagnose.go
+++ b/internal/lifecycle/diagnose.go
@@ -20,6 +20,9 @@ func (m *Machine) Diagnose(dir string) (report.Diagnosis, error) {
 		return d, err
 	}
 	d.Project = st
+	if st.Enabled {
+		d.OptionalSettings = m.optionalSettingStatuses(st)
+	}
 
 	// Observe, never Settled: only callers that act on the verdict pay
 	// to wait out a sibling's startup. A diagnosis reports the port as

--- a/internal/lifecycle/disable.go
+++ b/internal/lifecycle/disable.go
@@ -45,8 +45,8 @@ func (m *Machine) disableProject(projectDir string, io IO) (withdrawal, error) {
 		// A recorded setting write can outlive the rest of a withdrawal the
 		// same way spooled rawcalls can — an earlier disable that failed to
 		// restore kept the record — so the rerun reaches for it here too.
-		undone, failures := m.restoreRecordedSettings(st.Root, st.Hash)
-		reportRestoredSettings(io, undone, failures)
+		undone, failures := m.restoreRecordedSettings(st.Root, st.Hash, claudesettings.OptionalSettings)
+		reportRestoredSettings(io, "", undone, failures)
 		if err := m.purgeProjectRecords(st.Hash, &w); err != nil {
 			return w, fmt.Errorf("deleting local unuploaded data: %w", err)
 		}
@@ -71,8 +71,8 @@ func (m *Machine) disableProject(projectDir string, io IO) (withdrawal, error) {
 	if unrestored != "" {
 		fmt.Fprintf(io.Err, "trajector: WARNING: %s\n", unrestoredBaseURLWarning(settingsPath, unrestored))
 	}
-	undoneSettings, settingFailures := m.restoreRecordedSettings(st.Root, st.Hash)
-	reportRestoredSettings(io, undoneSettings, settingFailures)
+	undoneSettings, settingFailures := m.restoreRecordedSettings(st.Root, st.Hash, claudesettings.OptionalSettings)
+	reportRestoredSettings(io, "", undoneSettings, settingFailures)
 
 	now := m.now()
 	if err := m.routes.Revoke(st.Root, now); err != nil {

--- a/internal/lifecycle/disable.go
+++ b/internal/lifecycle/disable.go
@@ -42,10 +42,15 @@ func (m *Machine) disableProject(projectDir string, io IO) (withdrawal, error) {
 	// a no-op. Only the consent-changing steps are skipped now; the purge
 	// runs either way and stays silent when there is nothing to delete.
 	if !st.Injected() && !st.Enabled {
+		// A recorded setting write can outlive the rest of a withdrawal the
+		// same way spooled rawcalls can — an earlier disable that failed to
+		// restore kept the record — so the rerun reaches for it here too.
+		undone, failures := m.restoreRecordedSettings(st.Root, st.Hash)
+		reportRestoredSettings(io, undone, failures)
 		if err := m.purgeProjectRecords(st.Hash, &w); err != nil {
 			return w, fmt.Errorf("deleting local unuploaded data: %w", err)
 		}
-		if w.spooled+w.rejected == 0 {
+		if w.spooled+w.rejected == 0 && len(undone)+len(failures) == 0 {
 			fmt.Fprintln(io.Out, "This project is not enabled; nothing to do.")
 			return w, nil
 		}
@@ -66,6 +71,8 @@ func (m *Machine) disableProject(projectDir string, io IO) (withdrawal, error) {
 	if unrestored != "" {
 		fmt.Fprintf(io.Err, "trajector: WARNING: %s\n", unrestoredBaseURLWarning(settingsPath, unrestored))
 	}
+	undoneSettings, settingFailures := m.restoreRecordedSettings(st.Root, st.Hash)
+	reportRestoredSettings(io, undoneSettings, settingFailures)
 
 	now := m.now()
 	if err := m.routes.Revoke(st.Root, now); err != nil {

--- a/internal/lifecycle/discard.go
+++ b/internal/lifecycle/discard.go
@@ -30,7 +30,7 @@ func (m *Machine) DiscardRejected(batchID string, all, confirmed bool, io IO) er
 		}
 	}
 	if !confirmed {
-		yes, _ := askYesNo(io, discardPrompt(ids))
+		yes, _ := askYesNo(io, discardPrompt(ids), false)
 		if !yes {
 			fmt.Fprintln(io.Out, "Nothing was discarded.")
 			return nil

--- a/internal/lifecycle/doctor.go
+++ b/internal/lifecycle/doctor.go
@@ -127,6 +127,13 @@ func (m *Machine) doctorInjection(f *report.Findings, st report.ProjectStatus) e
 		if unrestored != "" {
 			f.Problem("%s", unrestoredBaseURLWarning(settingsPath, unrestored))
 		}
+		undone, failures := m.restoreRecordedSettings(st.Root, st.Hash)
+		for _, key := range undone {
+			f.Detail("%s", settingRestoredLine(key))
+		}
+		for _, err := range failures {
+			f.Problem("%v", err)
+		}
 		return nil
 	}
 

--- a/internal/lifecycle/doctor.go
+++ b/internal/lifecycle/doctor.go
@@ -127,7 +127,7 @@ func (m *Machine) doctorInjection(f *report.Findings, st report.ProjectStatus) e
 		if unrestored != "" {
 			f.Problem("%s", unrestoredBaseURLWarning(settingsPath, unrestored))
 		}
-		undone, failures := m.restoreRecordedSettings(st.Root, st.Hash)
+		undone, failures := m.restoreRecordedSettings(st.Root, st.Hash, claudesettings.OptionalSettings)
 		for _, key := range undone {
 			f.Detail("%s", settingRestoredLine(key))
 		}

--- a/internal/lifecycle/enable.go
+++ b/internal/lifecycle/enable.go
@@ -1,6 +1,7 @@
 package lifecycle
 
 import (
+	"bufio"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -40,6 +41,11 @@ func hookCommand(execPath, subcommand string) string {
 // half-enabled project routing traffic at a dead port must be
 // impossible.
 func (m *Machine) enableProject(projectDir string, io IO) error {
+	// Every prompt in one enable must read through one buffered reader: a
+	// second bufio over the same stream would find the bytes the first
+	// one buffered ahead already gone. bufio.NewReader hands this same
+	// reader back when the prompts wrap it again.
+	io.In = bufio.NewReader(io.In)
 	st, err := m.Project(projectDir)
 	if err != nil {
 		return err
@@ -174,6 +180,7 @@ func (m *Machine) installAndVerify(io IO, st report.ProjectStatus, upstream stri
 	if err := m.consent.SetProjectState(st.Hash, st.Root, consent.StateGranted, now); err != nil {
 		return fmt.Errorf("recording project consent: %w", err)
 	}
+	m.offerOptionalSettings(io, st)
 	if err := claudesettings.InjectProject(settingsPath, m.proxy.BaseURL(token), hookCommand(m.deps.ExecPath, "ensure-proxy")); err != nil {
 		return fmt.Errorf("injecting %s: %w", settingsPath, err)
 	}

--- a/internal/lifecycle/enable.go
+++ b/internal/lifecycle/enable.go
@@ -232,7 +232,7 @@ func (m *Machine) confirmAgreement(io IO) error {
 	}
 	fmt.Fprintln(io.Out, consent.AgreementText)
 	fmt.Fprintln(io.Out)
-	yes, err := askYesNo(io, "Do you accept the data agreement? [yes/no]: ")
+	yes, err := askYesNo(io, "Do you accept the data agreement? [yes/no]: ", false)
 	if err != nil {
 		return fmt.Errorf("reading agreement answer: %w", err)
 	}

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -60,15 +60,20 @@ type IO struct {
 	Err io.Writer
 }
 
-// askYesNo puts one yes/no question to the user. Only an explicit yes
-// answers true; a read that yields nothing at all is the error.
-func askYesNo(io IO, prompt string) (bool, error) {
+// askYesNo puts one yes/no question to the user. Empty input takes
+// def; otherwise only an explicit yes answers true. The error is a
+// read that yields nothing at all — a script, a pipeline, a closed
+// stdin — which is the one condition under which no question of any
+// kind can be answered.
+func askYesNo(io IO, prompt string, def bool) (bool, error) {
 	fmt.Fprint(io.Out, prompt)
 	line, err := bufio.NewReader(io.In).ReadString('\n')
 	if err != nil && line == "" {
 		return false, err
 	}
 	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "":
+		return def, nil
 	case "yes", "y":
 		return true, nil
 	}

--- a/internal/lifecycle/optional.go
+++ b/internal/lifecycle/optional.go
@@ -83,6 +83,28 @@ func (m *Machine) offerOptionalSettings(io IO, st report.ProjectStatus) {
 	}
 }
 
+// optionalSettingStatuses classifies every optional setting for the
+// diagnosis status renders. A decision store that cannot be read reads
+// as no decisions, exactly as when enable asks: every true then
+// classifies as the user's own.
+func (m *Machine) optionalSettingStatuses(st report.ProjectStatus) []report.OptionalSettingStatus {
+	decisions, err := m.consent.SettingDecisions(st.Hash)
+	if err != nil {
+		decisions = nil
+	}
+	statuses := make([]report.OptionalSettingStatus, 0, len(claudesettings.OptionalSettings))
+	for _, s := range claudesettings.OptionalSettings {
+		d, recorded := decisions[s.Key]
+		classified := claudesettings.ClassifySetting(st.Root, m.deps.Home, s.Key, recorded && wroteSetting(d))
+		statuses = append(statuses, report.OptionalSettingStatus{
+			Key:      s.Key,
+			State:    classified.State,
+			Declined: recorded && d.Answer == consent.AnswerDeclined,
+		})
+	}
+	return statuses
+}
+
 // applySettingAnswer records one answered question and carries an
 // acceptance out. Record before write: a write without its record could
 // never be undone — disable consults only the record — while a record

--- a/internal/lifecycle/optional.go
+++ b/internal/lifecycle/optional.go
@@ -1,7 +1,6 @@
 package lifecycle
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"strings"
@@ -42,13 +41,14 @@ func (m *Machine) offerOptionalSettings(io IO, st report.ProjectStatus) {
 			printWrapped(io.Out, statementIndent, fmt.Sprintf(
 				"%s is on for this project; trajector set it when you enabled. `trajector disable` puts it back.", s.Key))
 			fmt.Fprintln(io.Out)
-			off, answered := askSetting(io, "Turn it off? [y/N] ", false)
-			if !answered {
+			off, err := askYesNo(io, "Turn it off? [y/N] ", false)
+			if err != nil {
 				printNeedsInteractive(io)
 				return
 			}
 			if off {
-				m.turnOffOurSetting(io, st, s)
+				undone, failures := m.restoreRecordedSettings(st.Root, st.Hash, []claudesettings.OptionalSetting{s})
+				reportRestoredSettings(io, "  ", undone, failures)
 			}
 		case claudesettings.OffByUser:
 			printWrapped(io.Out, statementIndent, fmt.Sprintf("You have %s set to false in your %s.", s.Key, status.Source))
@@ -60,8 +60,8 @@ func (m *Machine) offerOptionalSettings(io IO, st report.ProjectStatus) {
 			fmt.Fprintln(io.Out)
 			printDisclosures(io.Out, s.Disclosures)
 			fmt.Fprintln(io.Out)
-			yes, answered := askSetting(io, "Turn it on for this project? [y/N] ", false)
-			if !answered {
+			yes, err := askYesNo(io, "Turn it on for this project? [y/N] ", false)
+			if err != nil {
 				printNeedsInteractive(io)
 				return
 			}
@@ -73,8 +73,8 @@ func (m *Machine) offerOptionalSettings(io IO, st report.ProjectStatus) {
 			fmt.Fprintln(io.Out)
 			printWrapped(io.Out, statementIndent, s.Fact)
 			fmt.Fprintln(io.Out)
-			yes, answered := askSetting(io, "Turn it on? [Y/n] ", true)
-			if !answered {
+			yes, err := askYesNo(io, "Turn it on? [Y/n] ", true)
+			if err != nil {
 				printNeedsInteractive(io)
 				return
 			}
@@ -149,19 +149,6 @@ func (m *Machine) applySettingAnswer(io IO, st report.ProjectStatus, s claudeset
 	}
 }
 
-// turnOffOurSetting is the enable-side undo: an OnByUs setting the user
-// just asked to turn off goes back through the same restore path
-// disable uses.
-func (m *Machine) turnOffOurSetting(io IO, st report.ProjectStatus, s claudesettings.OptionalSetting) {
-	undone, failures := m.restoreRecordedSettingKey(st.Root, st.Hash, s)
-	for _, key := range undone {
-		fmt.Fprintf(io.Out, "  %s\n", settingRestoredLine(key))
-	}
-	for _, err := range failures {
-		fmt.Fprintf(io.Err, "trajector: WARNING: %v\n", err)
-	}
-}
-
 // wroteSetting reports whether a recorded decision marks a write of
 // trajector's own: accepted, with a prior the write changed. An
 // acceptance that found the value already in place wrote nothing, so it
@@ -175,15 +162,21 @@ func wroteSetting(d consent.SettingDecision) bool {
 // restoreRecordedSettings undoes what a project's recorded setting
 // decisions say trajector wrote, for every surface that removes what
 // enable put in place: disable, uninstall, and doctor's stale-injection
-// repair all call it next to removeInjection. Declined answers are left
-// standing — one refusal keeps ending the ask across disable/enable
-// cycles. A record is cleared only once its restore succeeded: the
-// record is the only undo there is, so a failed restore must keep it.
-func (m *Machine) restoreRecordedSettings(root, hash string) (undone []string, failures []error) {
-	for _, s := range claudesettings.OptionalSettings {
-		u, f := m.restoreRecordedSettingKey(root, hash, s)
-		undone = append(undone, u...)
-		failures = append(failures, f...)
+// repair walk the whole table next to removeInjection, and enable's own
+// turn-off passes just the one setting the user answered about.
+// Declined answers are left standing — one refusal keeps ending the ask
+// across disable/enable cycles. A record is cleared only once its
+// restore succeeded: the record is the only undo there is, so a failed
+// restore must keep it.
+func (m *Machine) restoreRecordedSettings(root, hash string, settings []claudesettings.OptionalSetting) (undone []string, failures []error) {
+	for _, s := range settings {
+		restored, err := m.restoreRecordedSettingKey(root, hash, s)
+		if restored {
+			undone = append(undone, s.Key)
+		}
+		if err != nil {
+			failures = append(failures, err)
+		}
 	}
 	return undone, failures
 }
@@ -192,14 +185,14 @@ func (m *Machine) restoreRecordedSettings(root, hash string) (undone []string, f
 // setting: only a prior of absent or false marks a write to take back,
 // and the write comes back out only while the file still holds it — a
 // later hand edit is the user's most recent decision and wins.
-func (m *Machine) restoreRecordedSettingKey(root, hash string, s claudesettings.OptionalSetting) (undone []string, failures []error) {
+func (m *Machine) restoreRecordedSettingKey(root, hash string, s claudesettings.OptionalSetting) (restored bool, err error) {
 	decisions, err := m.consent.SettingDecisions(hash)
 	if err != nil {
-		return nil, []error{fmt.Errorf("reading the recorded setting decisions: %w", err)}
+		return false, fmt.Errorf("reading the recorded setting decisions: %w", err)
 	}
 	d, ok := decisions[s.Key]
 	if !ok || d.Answer != consent.AnswerAccepted {
-		return nil, nil
+		return false, nil
 	}
 	path := claudesettings.ProjectLocalPath(root)
 	acted := false
@@ -208,18 +201,15 @@ func (m *Machine) restoreRecordedSettingKey(root, hash string, s claudesettings.
 			acted = true
 		}
 		if err := claudesettings.RestoreTopLevelBool(path, s.Key, s.Target, false, d.Prior == consent.PriorFalse); err != nil {
-			return nil, []error{fmt.Errorf(
+			return false, fmt.Errorf(
 				"could not set %s back to what it was before trajector wrote it: %v (the record was kept so a rerun can retry)",
-				s.Key, err)}
+				s.Key, err)
 		}
 	}
 	if err := m.consent.ClearSettingDecision(hash, s.Key); err != nil {
-		return nil, []error{fmt.Errorf("could not clear the recorded decision for %s: %v (a rerun can retry)", s.Key, err)}
+		return false, fmt.Errorf("could not clear the recorded decision for %s: %v (a rerun can retry)", s.Key, err)
 	}
-	if acted {
-		undone = append(undone, s.Key)
-	}
-	return undone, nil
+	return acted, nil
 }
 
 // settingRestoredLine is the one sentence every surface prints when it
@@ -229,11 +219,12 @@ func settingRestoredLine(key string) string {
 	return fmt.Sprintf("Set %s back to what it was before trajector wrote it.", key)
 }
 
-// reportRestoredSettings prints one removal's setting restores the way
-// disable and uninstall report the rest of their work.
-func reportRestoredSettings(io IO, undone []string, failures []error) {
+// reportRestoredSettings prints setting restores and their failures the
+// same way on every surface; the indent is the only thing the surfaces
+// disagree on.
+func reportRestoredSettings(io IO, indent string, undone []string, failures []error) {
 	for _, key := range undone {
-		fmt.Fprintln(io.Out, settingRestoredLine(key))
+		fmt.Fprintf(io.Out, "%s%s\n", indent, settingRestoredLine(key))
 	}
 	for _, err := range failures {
 		fmt.Fprintf(io.Err, "trajector: WARNING: %v\n", err)
@@ -248,24 +239,6 @@ func reportRestoredSettings(io IO, undone []string, failures []error) {
 func printNeedsInteractive(io IO) {
 	fmt.Fprintln(io.Out, "Optional settings were not changed: they need an interactive session.")
 	fmt.Fprintln(io.Out, "Run `trajector enable` from a terminal to review them.")
-}
-
-// askSetting puts one optional-setting question. Empty input takes the
-// stated default; otherwise only an explicit yes answers true, as in
-// askYesNo. answered is false when the read yields nothing at all.
-func askSetting(io IO, prompt string, def bool) (yes, answered bool) {
-	fmt.Fprint(io.Out, prompt)
-	line, err := bufio.NewReader(io.In).ReadString('\n')
-	if err != nil && line == "" {
-		return false, false
-	}
-	switch strings.ToLower(strings.TrimSpace(line)) {
-	case "":
-		return def, true
-	case "yes", "y":
-		return true, true
-	}
-	return false, true
 }
 
 // Rendering re-wraps the finalized disclosure wording; it never rewrites

--- a/internal/lifecycle/optional.go
+++ b/internal/lifecycle/optional.go
@@ -1,0 +1,307 @@
+package lifecycle
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/PublicAI01/trajector-cli/internal/claudesettings"
+	"github.com/PublicAI01/trajector-cli/internal/consent"
+	"github.com/PublicAI01/trajector-cli/internal/report"
+)
+
+// offerOptionalSettings puts each optional Claude Code setting to the
+// user according to its classified state, writes the ones accepted, and
+// records every answer. It runs after the project's granted state is
+// recorded — a setting decision has no record to attach to before that
+// — and before injection. It never returns an error: a failure to ask,
+// write, or record degrades to "nothing changed", because the optional
+// ask must never break enable. Every question changes the file only on
+// an explicit yes: the suggested default and an answer of no both leave
+// it untouched, whichever way the question points.
+func (m *Machine) offerOptionalSettings(io IO, st report.ProjectStatus) {
+	// A decision store that cannot be read leaves writtenByUs unknowable;
+	// every true then classifies as the user's own, which disable will
+	// never delete. Failing toward not touching the user's value.
+	decisions, err := m.consent.SettingDecisions(st.Hash)
+	if err != nil {
+		decisions = nil
+	}
+	for _, s := range claudesettings.OptionalSettings {
+		d, recorded := decisions[s.Key]
+		status := claudesettings.ClassifySetting(st.Root, m.deps.Home, s.Key, recorded && wroteSetting(d))
+		fmt.Fprintf(io.Out, "\nOptional setting for this project\n\n")
+		switch status.State {
+		case claudesettings.OnByUser:
+			printWrapped(io.Out, statementIndent, fmt.Sprintf(
+				"%s is already true in your %s. Nothing to change. %s",
+				s.Key, status.Source, s.AlreadyOn))
+		case claudesettings.OnByUs:
+			printWrapped(io.Out, statementIndent, fmt.Sprintf(
+				"%s is on for this project; trajector set it when you enabled. `trajector disable` puts it back.", s.Key))
+			fmt.Fprintln(io.Out)
+			off, answered := askSetting(io, "Turn it off? [y/N] ", false)
+			if !answered {
+				printNeedsInteractive(io)
+				return
+			}
+			if off {
+				m.turnOffOurSetting(io, st, s)
+			}
+		case claudesettings.OffByUser:
+			printWrapped(io.Out, statementIndent, fmt.Sprintf("You have %s set to false in your %s.", s.Key, status.Source))
+			fmt.Fprintln(io.Out)
+			printWrapped(io.Out, statementIndent, fmt.Sprintf(
+				"Confirming would set it to %v for this project only, overriding that. "+
+					"You can leave it as false and nothing else changes — recording, "+
+					"rewards, and every other part of trajector work the same.", s.Target))
+			fmt.Fprintln(io.Out)
+			printDisclosures(io.Out, s.Disclosures)
+			fmt.Fprintln(io.Out)
+			yes, answered := askSetting(io, "Turn it on for this project? [y/N] ", false)
+			if !answered {
+				printNeedsInteractive(io)
+				return
+			}
+			m.applySettingAnswer(io, st, s, yes)
+		default: // Unset
+			printWrapped(io.Out, statementIndent, s.Intro)
+			fmt.Fprintln(io.Out)
+			printDisclosures(io.Out, s.Disclosures)
+			fmt.Fprintln(io.Out)
+			printWrapped(io.Out, statementIndent, s.Fact)
+			fmt.Fprintln(io.Out)
+			yes, answered := askSetting(io, "Turn it on? [Y/n] ", true)
+			if !answered {
+				printNeedsInteractive(io)
+				return
+			}
+			m.applySettingAnswer(io, st, s, yes)
+		}
+	}
+}
+
+// applySettingAnswer records one answered question and carries an
+// acceptance out. Record before write: a write without its record could
+// never be undone — disable consults only the record — while a record
+// without its write restores nothing, because RestoreTopLevelBool acts
+// only when the current value is the one trajector wrote. The failure
+// that can land between the two is the harmless one in this order.
+func (m *Machine) applySettingAnswer(io IO, st report.ProjectStatus, s claudesettings.OptionalSetting, accepted bool) {
+	if !accepted {
+		if err := m.consent.SetSettingDecision(st.Hash, s.Key, consent.SettingDecision{
+			Answer:    consent.AnswerDeclined,
+			DecidedAt: m.now(),
+		}); err != nil {
+			fmt.Fprintf(io.Err, "trajector: WARNING: could not record your answer for %s: %v\n", s.Key, err)
+		}
+		return
+	}
+	prior := consent.PriorAbsent
+	if value, found := claudesettings.TopLevelBool(st.SettingsPath(), s.Key); found {
+		prior = consent.PriorFalse
+		if value {
+			prior = consent.PriorTrue
+		}
+	}
+	if err := m.consent.SetSettingDecision(st.Hash, s.Key, consent.SettingDecision{
+		Answer:    consent.AnswerAccepted,
+		Prior:     prior,
+		DecidedAt: m.now(),
+	}); err != nil {
+		fmt.Fprintf(io.Err, "trajector: WARNING: could not turn on %s; nothing was changed: %v\n", s.Key, err)
+		return
+	}
+	if prior == consent.PriorTrue {
+		// Already holds the value the user just accepted; writing nothing
+		// keeps it theirs, and the recorded prior keeps disable's hands off.
+		return
+	}
+	if err := claudesettings.SetTopLevelBool(st.SettingsPath(), s.Key, s.Target); err != nil {
+		// The record just made claims a write that did not happen; taking
+		// it back keeps a rerun asking instead of standing on a stale claim.
+		_ = m.consent.ClearSettingDecision(st.Hash, s.Key)
+		fmt.Fprintf(io.Err, "trajector: WARNING: could not turn on %s; nothing was changed: %v\n", s.Key, err)
+	}
+}
+
+// turnOffOurSetting is the enable-side undo: an OnByUs setting the user
+// just asked to turn off goes back through the same restore path
+// disable uses.
+func (m *Machine) turnOffOurSetting(io IO, st report.ProjectStatus, s claudesettings.OptionalSetting) {
+	undone, failures := m.restoreRecordedSettingKey(st.Root, st.Hash, s)
+	for _, key := range undone {
+		fmt.Fprintf(io.Out, "  %s\n", settingRestoredLine(key))
+	}
+	for _, err := range failures {
+		fmt.Fprintf(io.Err, "trajector: WARNING: %v\n", err)
+	}
+}
+
+// wroteSetting reports whether a recorded decision marks a write of
+// trajector's own: accepted, with a prior the write changed. An
+// acceptance that found the value already in place wrote nothing, so it
+// never counts — counting it is how disable would come to delete a
+// value the user set.
+func wroteSetting(d consent.SettingDecision) bool {
+	return d.Answer == consent.AnswerAccepted &&
+		(d.Prior == consent.PriorAbsent || d.Prior == consent.PriorFalse)
+}
+
+// restoreRecordedSettings undoes what a project's recorded setting
+// decisions say trajector wrote, for every surface that removes what
+// enable put in place: disable, uninstall, and doctor's stale-injection
+// repair all call it next to removeInjection. Declined answers are left
+// standing — one refusal keeps ending the ask across disable/enable
+// cycles. A record is cleared only once its restore succeeded: the
+// record is the only undo there is, so a failed restore must keep it.
+func (m *Machine) restoreRecordedSettings(root, hash string) (undone []string, failures []error) {
+	for _, s := range claudesettings.OptionalSettings {
+		u, f := m.restoreRecordedSettingKey(root, hash, s)
+		undone = append(undone, u...)
+		failures = append(failures, f...)
+	}
+	return undone, failures
+}
+
+// restoreRecordedSettingKey applies the decision table to one accepted
+// setting: only a prior of absent or false marks a write to take back,
+// and the write comes back out only while the file still holds it — a
+// later hand edit is the user's most recent decision and wins.
+func (m *Machine) restoreRecordedSettingKey(root, hash string, s claudesettings.OptionalSetting) (undone []string, failures []error) {
+	decisions, err := m.consent.SettingDecisions(hash)
+	if err != nil {
+		return nil, []error{fmt.Errorf("reading the recorded setting decisions: %w", err)}
+	}
+	d, ok := decisions[s.Key]
+	if !ok || d.Answer != consent.AnswerAccepted {
+		return nil, nil
+	}
+	path := claudesettings.ProjectLocalPath(root)
+	acted := false
+	if wroteSetting(d) {
+		if current, found := claudesettings.TopLevelBool(path, s.Key); found && current == s.Target {
+			acted = true
+		}
+		if err := claudesettings.RestoreTopLevelBool(path, s.Key, s.Target, false, d.Prior == consent.PriorFalse); err != nil {
+			return nil, []error{fmt.Errorf(
+				"could not set %s back to what it was before trajector wrote it: %v (the record was kept so a rerun can retry)",
+				s.Key, err)}
+		}
+	}
+	if err := m.consent.ClearSettingDecision(hash, s.Key); err != nil {
+		return nil, []error{fmt.Errorf("could not clear the recorded decision for %s: %v (a rerun can retry)", s.Key, err)}
+	}
+	if acted {
+		undone = append(undone, s.Key)
+	}
+	return undone, nil
+}
+
+// settingRestoredLine is the one sentence every surface prints when it
+// puts a setting back, so disable, uninstall, and enable's own undo
+// cannot describe the same act differently.
+func settingRestoredLine(key string) string {
+	return fmt.Sprintf("Set %s back to what it was before trajector wrote it.", key)
+}
+
+// reportRestoredSettings prints one removal's setting restores the way
+// disable and uninstall report the rest of their work.
+func reportRestoredSettings(io IO, undone []string, failures []error) {
+	for _, key := range undone {
+		fmt.Fprintln(io.Out, settingRestoredLine(key))
+	}
+	for _, err := range failures {
+		fmt.Fprintf(io.Err, "trajector: WARNING: %v\n", err)
+	}
+}
+
+// printNeedsInteractive says why nothing was asked and nothing changed.
+// The condition is the one under which the agreement prompt cannot ask
+// either: the read yields no answer at all, which is what a script, a
+// pipeline, or a closed stdin look like — and none of the disclosure
+// conditions can be met when nobody is reading.
+func printNeedsInteractive(io IO) {
+	fmt.Fprintln(io.Out, "Optional settings were not changed: they need an interactive session.")
+	fmt.Fprintln(io.Out, "Run `trajector enable` from a terminal to review them.")
+}
+
+// askSetting puts one optional-setting question. Empty input takes the
+// stated default; otherwise only an explicit yes answers true, as in
+// askYesNo. answered is false when the read yields nothing at all.
+func askSetting(io IO, prompt string, def bool) (yes, answered bool) {
+	fmt.Fprint(io.Out, prompt)
+	line, err := bufio.NewReader(io.In).ReadString('\n')
+	if err != nil && line == "" {
+		return false, false
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "":
+		return def, true
+	case "yes", "y":
+		return true, true
+	}
+	return false, true
+}
+
+// Rendering re-wraps the finalized disclosure wording; it never rewrites
+// a word of it. The width matches the prototype the wording came from.
+const (
+	settingScreenWidth = 73
+	statementIndent    = 2
+	// disclosureGap separates the longest label from its text.
+	disclosureGap = 3
+)
+
+// printWrapped prints text as one greedily wrapped, indented paragraph.
+func printWrapped(w io.Writer, indent int, text string) {
+	pad := strings.Repeat(" ", indent)
+	for _, line := range wrapText(text, settingScreenWidth-indent) {
+		fmt.Fprintf(w, "%s%s\n", pad, line)
+	}
+}
+
+// printDisclosures lays the labeled rows out in two columns: labels
+// left, text wrapped in a column starting past the longest label.
+func printDisclosures(w io.Writer, disclosures []claudesettings.Disclosure) {
+	width := 0
+	for _, d := range disclosures {
+		if n := utf8.RuneCountInString(d.Label); n > width {
+			width = n
+		}
+	}
+	textCol := statementIndent + width + disclosureGap
+	for _, d := range disclosures {
+		lines := wrapText(d.Text, settingScreenWidth-textCol)
+		for i, line := range lines {
+			if i == 0 {
+				fmt.Fprintf(w, "%s%-*s%s\n", strings.Repeat(" ", statementIndent), width+disclosureGap, d.Label, line)
+				continue
+			}
+			fmt.Fprintf(w, "%s%s\n", strings.Repeat(" ", textCol), line)
+		}
+	}
+}
+
+// wrapText greedily wraps text at width, measured in runes.
+func wrapText(text string, width int) []string {
+	var lines []string
+	line := ""
+	for _, word := range strings.Fields(text) {
+		switch {
+		case line == "":
+			line = word
+		case utf8.RuneCountInString(line)+1+utf8.RuneCountInString(word) <= width:
+			line += " " + word
+		default:
+			lines = append(lines, line)
+			line = word
+		}
+	}
+	if line != "" {
+		lines = append(lines, line)
+	}
+	return lines
+}

--- a/internal/lifecycle/optional_test.go
+++ b/internal/lifecycle/optional_test.go
@@ -1,0 +1,578 @@
+package lifecycle_test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PublicAI01/trajector-cli/internal/claudesettings"
+	"github.com/PublicAI01/trajector-cli/internal/consent"
+	"github.com/PublicAI01/trajector-cli/internal/lifecycle"
+)
+
+const optionalKey = claudesettings.KeyShowThinkingSummaries
+
+// containsWrapped reports whether out contains want regardless of where
+// rendering wrapped its lines.
+func containsWrapped(out, want string) bool {
+	return strings.Contains(strings.Join(strings.Fields(out), " "), want)
+}
+
+func settingValue(t *testing.T, path string) (value, found bool) {
+	t.Helper()
+	return claudesettings.TopLevelBool(path, optionalKey)
+}
+
+func settingDecision(t *testing.T, e *env, hash string) (consent.SettingDecision, bool) {
+	t.Helper()
+	decisions, err := e.consentStore().SettingDecisions(hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, ok := decisions[optionalKey]
+	return d, ok
+}
+
+func writeUserSettings(t *testing.T, e *env, contents string) {
+	t.Helper()
+	path := claudesettings.UserSettingsPath(e.deps.Home)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeProjectLocalSettings(t *testing.T, e *env, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(e.settingsPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(e.settingsPath(), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnableAsksAndWritesTheOptionalSettingOnYes(t *testing.T) {
+	e := newEnv(t)
+	e.startProxy()
+	e.stdin = "yes\ny\n"
+
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("enable: %v\nstdout: %s", err, e.stdout)
+	}
+
+	out := e.stdout.String()
+	for _, want := range []string{
+		"Optional setting for this project",
+		"What changes",
+		optionalKey + " becomes true in",
+		"more valuable to us",
+		"Claude Code stopped generating these summaries by default in",
+		"Turn it on? [Y/n]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout misses %q:\n%s", want, out)
+		}
+	}
+	if strings.Index(out, "Turn it on?") > strings.Index(out, "Injected ") {
+		t.Error("the question came after injection; it must come before")
+	}
+	if value, found := settingValue(t, e.settingsPath()); !found || !value {
+		t.Errorf("setting = %v, %v after yes, want true", value, found)
+	}
+	d, ok := settingDecision(t, e, e.status().Hash)
+	if !ok || d.Answer != consent.AnswerAccepted || d.Prior != consent.PriorAbsent {
+		t.Errorf("decision = %+v, %v, want accepted with an absent prior", d, ok)
+	}
+}
+
+func TestEnableEmptyInputTakesTheStatedDefault(t *testing.T) {
+	cases := []struct {
+		name       string
+		seed       func(t *testing.T, e *env)
+		wantPrompt string
+		wantSaid   string
+		wantOn     bool
+		wantAnswer consent.SettingAnswer
+	}{
+		{
+			name:       "an unset setting suggests yes",
+			seed:       func(*testing.T, *env) {},
+			wantPrompt: "Turn it on? [Y/n]",
+			wantSaid:   "Optional setting for this project",
+			wantOn:     true,
+			wantAnswer: consent.AnswerAccepted,
+		},
+		{
+			name: "a setting the user turned off suggests no",
+			seed: func(t *testing.T, e *env) {
+				writeUserSettings(t, e, `{"showThinkingSummaries": false}`)
+			},
+			wantPrompt: "Turn it on for this project? [y/N]",
+			wantSaid:   "You have showThinkingSummaries set to false in your user settings.json.",
+			wantOn:     false,
+			wantAnswer: consent.AnswerDeclined,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newEnv(t)
+			e.startProxy()
+			tc.seed(t, e)
+			e.stdin = "yes\n\n"
+
+			if err := e.machine().Enable(e.project, e.io()); err != nil {
+				t.Fatalf("enable: %v\nstdout: %s", err, e.stdout)
+			}
+			out := e.stdout.String()
+			if !strings.Contains(out, tc.wantPrompt) {
+				t.Errorf("stdout misses %q:\n%s", tc.wantPrompt, out)
+			}
+			if !containsWrapped(out, tc.wantSaid) {
+				t.Errorf("stdout misses %q:\n%s", tc.wantSaid, out)
+			}
+			if value, found := settingValue(t, e.settingsPath()); (found && value) != tc.wantOn {
+				t.Errorf("setting = %v, %v, want on=%v", value, found, tc.wantOn)
+			}
+			if d, ok := settingDecision(t, e, e.status().Hash); !ok || d.Answer != tc.wantAnswer {
+				t.Errorf("decision = %+v, %v, want %q", d, ok, tc.wantAnswer)
+			}
+		})
+	}
+}
+
+func TestEnableDeclineIsRecordedAndRerunStillAsks(t *testing.T) {
+	e := newEnv(t)
+	e.startProxy()
+	e.stdin = "yes\nn\n"
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if value, found := settingValue(t, e.settingsPath()); found {
+		t.Errorf("declining still wrote the setting: %v", value)
+	}
+	if d, ok := settingDecision(t, e, e.status().Hash); !ok || d.Answer != consent.AnswerDeclined {
+		t.Errorf("decision = %+v, %v, want declined", d, ok)
+	}
+
+	e.stdout.Reset()
+	e.stdin = "y\n"
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("rerun: %v", err)
+	}
+	if !strings.Contains(e.stdout.String(), "Turn it on? [Y/n]") {
+		t.Errorf("rerun after a decline did not ask again:\n%s", e.stdout)
+	}
+	if value, found := settingValue(t, e.settingsPath()); !found || !value {
+		t.Errorf("setting = %v, %v after changing the answer to yes, want true", value, found)
+	}
+}
+
+func TestEnableLeavesAUsersOwnTrueAlone(t *testing.T) {
+	cases := []struct {
+		name     string
+		seed     func(t *testing.T, e *env)
+		wantSaid string
+		stillOn  func(t *testing.T, e *env) bool
+	}{
+		{
+			name: "in the user settings",
+			seed: func(t *testing.T, e *env) {
+				writeUserSettings(t, e, `{"showThinkingSummaries": true}`)
+			},
+			wantSaid: "showThinkingSummaries is already true in your user settings.json.",
+			stillOn: func(t *testing.T, e *env) bool {
+				value, found := claudesettings.TopLevelBool(claudesettings.UserSettingsPath(e.deps.Home), optionalKey)
+				return found && value
+			},
+		},
+		{
+			name: "in the project-local settings",
+			seed: func(t *testing.T, e *env) {
+				writeProjectLocalSettings(t, e, `{"showThinkingSummaries": true}`)
+			},
+			wantSaid: "showThinkingSummaries is already true in your project settings.local.json.",
+			stillOn: func(t *testing.T, e *env) bool {
+				value, found := settingValue(t, e.settingsPath())
+				return found && value
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newEnv(t)
+			e.startProxy()
+			tc.seed(t, e)
+
+			if err := e.machine().Enable(e.project, e.io()); err != nil {
+				t.Fatalf("enable: %v\nstdout: %s", err, e.stdout)
+			}
+			out := e.stdout.String()
+			if !containsWrapped(out, tc.wantSaid) {
+				t.Errorf("stdout misses %q:\n%s", tc.wantSaid, out)
+			}
+			if strings.Contains(out, "Turn it on?") || strings.Contains(out, "Turn it off?") {
+				t.Errorf("a value the user set was questioned:\n%s", out)
+			}
+			if _, ok := settingDecision(t, e, e.status().Hash); ok {
+				t.Error("a value the user set was recorded")
+			}
+
+			if err := e.machine().Disable(e.project, false, e.io()); err != nil {
+				t.Fatalf("disable: %v", err)
+			}
+			if !tc.stillOn(t, e) {
+				t.Error("disable removed a true the user set themselves")
+			}
+		})
+	}
+}
+
+// editThenAnswer answers a prompt only after making an edit first, the
+// way a user who changes a file while the question is on screen does.
+type editThenAnswer struct {
+	edit   func()
+	answer io.Reader
+	edited bool
+}
+
+func (r *editThenAnswer) Read(p []byte) (int, error) {
+	if !r.edited {
+		r.edited = true
+		r.edit()
+	}
+	return r.answer.Read(p)
+}
+
+func TestEnableAcceptWhenAlreadyTrueRecordsNoWriteOfOurs(t *testing.T) {
+	e := newEnv(t)
+	e.startProxy()
+	e.stdin = "yes\nn\n"
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	in := &editThenAnswer{
+		edit: func() {
+			if err := claudesettings.SetTopLevelBool(e.settingsPath(), optionalKey, true); err != nil {
+				t.Error(err)
+			}
+		},
+		answer: strings.NewReader("y\n"),
+	}
+	if err := e.machine().Enable(e.project, lifecycle.IO{In: in, Out: e.stdout, Err: e.stderr}); err != nil {
+		t.Fatalf("rerun: %v\nstdout: %s", err, e.stdout)
+	}
+	d, ok := settingDecision(t, e, e.status().Hash)
+	if !ok || d.Answer != consent.AnswerAccepted || d.Prior != consent.PriorTrue {
+		t.Errorf("decision = %+v, %v, want accepted with a true prior", d, ok)
+	}
+
+	if err := e.machine().Disable(e.project, false, e.io()); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if value, found := settingValue(t, e.settingsPath()); !found || !value {
+		t.Errorf("disable touched a true trajector never wrote: %v, %v", value, found)
+	}
+}
+
+func TestEnableRecordFailureLeavesTheSettingUnwritten(t *testing.T) {
+	e := newEnv(t)
+	e.startProxy()
+	e.stdin = "yes\nn\n"
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	in := &editThenAnswer{
+		edit: func() {
+			if err := os.WriteFile(e.deps.Layout.ConsentFile(), []byte("{ not json"), 0o600); err != nil {
+				t.Error(err)
+			}
+		},
+		answer: strings.NewReader("y\n"),
+	}
+	if err := e.machine().Enable(e.project, lifecycle.IO{In: in, Out: e.stdout, Err: e.stderr}); err != nil {
+		t.Fatalf("rerun: %v\nstdout: %s\nstderr: %s", err, e.stdout, e.stderr)
+	}
+	if !strings.Contains(e.stderr.String(), "nothing was changed") {
+		t.Errorf("stderr misses the degraded outcome:\n%s", e.stderr)
+	}
+	if value, found := settingValue(t, e.settingsPath()); found {
+		t.Errorf("the setting was written without its record: %v", value)
+	}
+}
+
+func TestEnableRerunStatesOurWriteAndKeepsItWithoutAnExplicitYes(t *testing.T) {
+	for _, input := range []string{"\n", "n\n"} {
+		t.Run(strings.TrimSuffix(input, "\n")+"<enter>", func(t *testing.T) {
+			e := newEnv(t)
+			e.startProxy()
+			e.stdin = "yes\ny\n"
+			if err := e.machine().Enable(e.project, e.io()); err != nil {
+				t.Fatalf("enable: %v", err)
+			}
+
+			e.stdout.Reset()
+			e.stdin = input
+			if err := e.machine().Enable(e.project, e.io()); err != nil {
+				t.Fatalf("rerun: %v", err)
+			}
+			out := e.stdout.String()
+			if !strings.Contains(out, "showThinkingSummaries is on for this project; trajector set it when") {
+				t.Errorf("stdout misses the rerun statement:\n%s", out)
+			}
+			if !strings.Contains(out, "Turn it off? [y/N]") {
+				t.Errorf("stdout misses the turn-off question:\n%s", out)
+			}
+			if value, found := settingValue(t, e.settingsPath()); !found || !value {
+				t.Errorf("an answer short of an explicit yes turned the setting off: %v, %v", value, found)
+			}
+			if d, ok := settingDecision(t, e, e.status().Hash); !ok || d.Prior != consent.PriorAbsent {
+				t.Errorf("decision = %+v, %v, want the original record kept", d, ok)
+			}
+		})
+	}
+}
+
+func TestEnableRerunAnswerYesTurnsTheSettingBackOff(t *testing.T) {
+	e := newEnv(t)
+	e.startProxy()
+	e.stdin = "yes\ny\n"
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	e.stdout.Reset()
+	e.stdin = "y\n"
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("rerun: %v", err)
+	}
+	if !strings.Contains(e.stdout.String(), "Set showThinkingSummaries back to what it was before trajector wrote it.") {
+		t.Errorf("stdout misses the undo line:\n%s", e.stdout)
+	}
+	if _, found := settingValue(t, e.settingsPath()); found {
+		t.Error("the key survived being turned back off")
+	}
+	if _, ok := settingDecision(t, e, e.status().Hash); ok {
+		t.Error("the record survived a successful restore")
+	}
+
+	e.stdout.Reset()
+	e.stdin = "n\n"
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("third run: %v", err)
+	}
+	if !strings.Contains(e.stdout.String(), "Turn it on? [Y/n]") {
+		t.Errorf("after turning it off the rerun did not ask afresh:\n%s", e.stdout)
+	}
+}
+
+func TestDisableRestoresTheSettingToItsPriorState(t *testing.T) {
+	cases := []struct {
+		name      string
+		seed      func(t *testing.T, e *env)
+		wantAfter func(value, found bool) bool
+	}{
+		{
+			name:      "an absent key is deleted",
+			seed:      func(*testing.T, *env) {},
+			wantAfter: func(_, found bool) bool { return !found },
+		},
+		{
+			name: "an explicit false comes back",
+			seed: func(t *testing.T, e *env) {
+				writeProjectLocalSettings(t, e, `{"showThinkingSummaries": false}`)
+			},
+			wantAfter: func(value, found bool) bool { return found && !value },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newEnv(t)
+			e.startProxy()
+			tc.seed(t, e)
+			e.stdin = "yes\ny\n"
+			if err := e.machine().Enable(e.project, e.io()); err != nil {
+				t.Fatalf("enable: %v\nstdout: %s", err, e.stdout)
+			}
+			if value, found := settingValue(t, e.settingsPath()); !found || !value {
+				t.Fatalf("test setup: setting = %v, %v after accepting, want true", value, found)
+			}
+
+			e.stdout.Reset()
+			if err := e.machine().Disable(e.project, false, e.io()); err != nil {
+				t.Fatalf("disable: %v", err)
+			}
+			if !strings.Contains(e.stdout.String(), "Set showThinkingSummaries back to what it was before trajector wrote it.") {
+				t.Errorf("stdout misses the undo line:\n%s", e.stdout)
+			}
+			if value, found := settingValue(t, e.settingsPath()); !tc.wantAfter(value, found) {
+				t.Errorf("setting after disable = %v, %v", value, found)
+			}
+			if _, ok := settingDecision(t, e, e.status().Hash); ok {
+				t.Error("the record survived a successful restore")
+			}
+		})
+	}
+}
+
+func TestDisableLeavesAHandEditedValueAlone(t *testing.T) {
+	e := newEnv(t)
+	e.startProxy()
+	e.stdin = "yes\ny\n"
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if err := claudesettings.SetTopLevelBool(e.settingsPath(), optionalKey, false); err != nil {
+		t.Fatal(err)
+	}
+
+	e.stdout.Reset()
+	if err := e.machine().Disable(e.project, false, e.io()); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if value, found := settingValue(t, e.settingsPath()); !found || value {
+		t.Errorf("setting = %v, %v, want the hand-edited false kept", value, found)
+	}
+	if strings.Contains(e.stdout.String(), "Set showThinkingSummaries back") {
+		t.Errorf("disable claims an undo it did not perform:\n%s", e.stdout)
+	}
+	if _, ok := settingDecision(t, e, e.status().Hash); ok {
+		t.Error("the record outlived the decision it was for")
+	}
+}
+
+func TestDisableKeepsTheRecordWhenRestoreFails(t *testing.T) {
+	e := newEnv(t)
+	hash := e.status().Hash
+	consents := e.consentStore()
+	if err := consents.SetProjectState(hash, e.canonicalRoot(), consent.StateGranted, "2026-08-02T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := consents.SetSettingDecision(hash, optionalKey, consent.SettingDecision{
+		Answer: consent.AnswerAccepted, Prior: consent.PriorAbsent, DecidedAt: "2026-08-02T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeProjectLocalSettings(t, e, "{ not json")
+
+	if err := e.machine().Disable(e.project, false, e.io()); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if !strings.Contains(e.stderr.String(), "could not set showThinkingSummaries back") {
+		t.Errorf("stderr misses the restore failure:\n%s", e.stderr)
+	}
+	if d, ok := settingDecision(t, e, hash); !ok || d.Answer != consent.AnswerAccepted {
+		t.Errorf("decision = %+v, %v; a failed restore must keep its record", d, ok)
+	}
+
+	writeProjectLocalSettings(t, e, `{"showThinkingSummaries": true}`)
+	e.stdout.Reset()
+	if err := e.machine().Disable(e.project, false, e.io()); err != nil {
+		t.Fatalf("rerun: %v", err)
+	}
+	if _, found := settingValue(t, e.settingsPath()); found {
+		t.Error("the rerun did not finish the restore")
+	}
+	if _, ok := settingDecision(t, e, hash); ok {
+		t.Error("the record survived the finished restore")
+	}
+}
+
+func TestEnableNonInteractiveChangesNoOptionalSetting(t *testing.T) {
+	e := newEnv(t)
+	e.startProxy()
+	e.stdin = "yes\n"
+
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("enable: %v\nstdout: %s", err, e.stdout)
+	}
+	out := e.stdout.String()
+	if !strings.Contains(out, "Optional settings were not changed: they need an interactive session.") ||
+		!strings.Contains(out, "Run `trajector enable` from a terminal to review them.") {
+		t.Errorf("stdout misses the non-interactive notice:\n%s", out)
+	}
+	if _, found := settingValue(t, e.settingsPath()); found {
+		t.Error("a non-interactive enable wrote the setting")
+	}
+	if _, ok := settingDecision(t, e, e.status().Hash); ok {
+		t.Error("a non-interactive enable recorded an answer nobody gave")
+	}
+}
+
+func TestDisableLeavesDeclinedRecordsInPlace(t *testing.T) {
+	e := newEnv(t)
+	e.startProxy()
+	e.stdin = "yes\nn\n"
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if err := e.machine().Disable(e.project, false, e.io()); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if d, ok := settingDecision(t, e, e.status().Hash); !ok || d.Answer != consent.AnswerDeclined {
+		t.Errorf("decision = %+v, %v; one refusal must survive disable", d, ok)
+	}
+}
+
+func TestUninstallRestoresSettingsAcrossRoots(t *testing.T) {
+	e := newEnv(t)
+	e.startProxy()
+	second := t.TempDir()
+	e.stdin = "yes\ny\n"
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("enable first project: %v", err)
+	}
+	e.stdin = "y\n"
+	if err := e.machine().Enable(second, e.io()); err != nil {
+		t.Fatalf("enable second project: %v", err)
+	}
+	secondRoot, err := consent.CanonicalRoot(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondSettings := claudesettings.ProjectLocalPath(secondRoot)
+	if value, found := settingValue(t, secondSettings); !found || !value {
+		t.Fatalf("test setup: second project setting = %v, %v, want true", value, found)
+	}
+
+	e.stdout.Reset()
+	e.stdin = "no\n"
+	if err := e.machine().Uninstall(false, e.io()); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if _, found := settingValue(t, e.settingsPath()); found {
+		t.Error("uninstall left trajector's write in the first project")
+	}
+	if _, found := settingValue(t, secondSettings); found {
+		t.Error("uninstall left trajector's write in the second project")
+	}
+	if n := strings.Count(e.stdout.String(), "Set showThinkingSummaries back to what it was before trajector wrote it."); n != 2 {
+		t.Errorf("undo line printed %d time(s), want one per project:\n%s", n, e.stdout)
+	}
+}
+
+func TestDoctorCompletesTheWithdrawalOfAWrittenSetting(t *testing.T) {
+	e := newEnv(t)
+	e.startProxy()
+	e.stdin = "yes\ny\n"
+	if err := e.machine().Enable(e.project, e.io()); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	e.sandbox.RevokeProject(e.canonicalRoot(), "2026-08-21T00:00:00Z")
+
+	if _, err := e.machine().Doctor(e.project, e.io()); err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+	if _, found := settingValue(t, e.settingsPath()); found {
+		t.Error("doctor removed the stale injection but left trajector's setting write")
+	}
+	if _, ok := settingDecision(t, e, e.status().Hash); ok {
+		t.Error("the record survived doctor's restore")
+	}
+}

--- a/internal/lifecycle/project.go
+++ b/internal/lifecycle/project.go
@@ -138,12 +138,20 @@ func (m *Machine) Uninstall(deleteData bool, io IO) error {
 	if err != nil {
 		return err
 	}
-	seen := map[string]bool{}
+	// The hash rides with each root so the recorded setting decisions —
+	// keyed by hash — can be honored for every project the table held,
+	// including ones whose directory is gone.
+	hashes := map[string]string{}
 	var projects []string
 	for _, g := range grants {
-		if g.RootPath != "" && !seen[g.RootPath] {
-			seen[g.RootPath] = true
+		if g.RootPath == "" {
+			continue
+		}
+		if _, ok := hashes[g.RootPath]; !ok {
 			projects = append(projects, g.RootPath)
+		}
+		if _, ok := hashes[g.RootPath]; !ok || !g.Revoked {
+			hashes[g.RootPath] = g.ProjectIDHash
 		}
 	}
 	sort.Strings(projects)
@@ -153,15 +161,17 @@ func (m *Machine) Uninstall(deleteData bool, io IO) error {
 		restored, unrestored, err := m.removeInjection(root)
 		if err != nil {
 			fmt.Fprintf(io.Err, "trajector: warning: could not clean %s: %v\n", path, err)
-			continue
+		} else {
+			removed++
+			if restored != "" {
+				fmt.Fprintf(io.Out, "Restored your own base URL in %s: %s\n", path, restored)
+			}
+			if unrestored != "" {
+				fmt.Fprintf(io.Err, "trajector: WARNING: %s\n", unrestoredBaseURLWarning(path, unrestored))
+			}
 		}
-		removed++
-		if restored != "" {
-			fmt.Fprintf(io.Out, "Restored your own base URL in %s: %s\n", path, restored)
-		}
-		if unrestored != "" {
-			fmt.Fprintf(io.Err, "trajector: WARNING: %s\n", unrestoredBaseURLWarning(path, unrestored))
-		}
+		undone, failures := m.restoreRecordedSettings(root, hashes[root])
+		reportRestoredSettings(io, undone, failures)
 	}
 	fmt.Fprintf(io.Out, "Removed injection from %d project(s).\n", removed)
 	for _, root := range projects {

--- a/internal/lifecycle/project.go
+++ b/internal/lifecycle/project.go
@@ -132,7 +132,7 @@ func leftoverIgnoreRules(root string) []string {
 // decided (deleteData false) is asked here, before anything changes.
 func (m *Machine) Uninstall(deleteData bool, io IO) error {
 	if !deleteData {
-		deleteData, _ = askYesNo(io, "Delete local data (captured rawcalls, configuration, device token)? [y/N]: ")
+		deleteData, _ = askYesNo(io, "Delete local data (captured rawcalls, configuration, device token)? [y/N]: ", false)
 	}
 	grants, err := m.routes.All()
 	if err != nil {
@@ -170,8 +170,8 @@ func (m *Machine) Uninstall(deleteData bool, io IO) error {
 				fmt.Fprintf(io.Err, "trajector: WARNING: %s\n", unrestoredBaseURLWarning(path, unrestored))
 			}
 		}
-		undone, failures := m.restoreRecordedSettings(root, hashes[root])
-		reportRestoredSettings(io, undone, failures)
+		undone, failures := m.restoreRecordedSettings(root, hashes[root], claudesettings.OptionalSettings)
+		reportRestoredSettings(io, "", undone, failures)
 	}
 	fmt.Fprintf(io.Out, "Removed injection from %d project(s).\n", removed)
 	for _, root := range projects {

--- a/internal/lifecycle/status_test.go
+++ b/internal/lifecycle/status_test.go
@@ -52,6 +52,80 @@ func TestStatusShowsTheStateOfADeviceThatJustEnabledAProject(t *testing.T) {
 	}
 }
 
+// What the optional-settings line says is settled at the renderer;
+// this is that the diagnosis hands it the state enable left behind.
+func TestStatusCarriesTheOptionalSettingAnswerEnableRecorded(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		seed   func(t *testing.T, e *env)
+		stdin  string
+		want   string
+		reject string
+	}{
+		{
+			name:  "accepted and written by trajector",
+			stdin: "yes\ny\n",
+			want:  "Optional settings: " + optionalKey + " on (set by trajector).",
+		},
+		{
+			name:   "declined once",
+			stdin:  "yes\nn\n",
+			want:   "Optional settings: 1 declined. Run `trajector enable` to review.",
+			reject: "costs you nothing",
+		},
+		{
+			name: "on as the user's own choice",
+			seed: func(t *testing.T, e *env) {
+				writeUserSettings(t, e, `{"showThinkingSummaries": true}`)
+			},
+			stdin:  "yes\n",
+			want:   "Optional settings: " + optionalKey + " on.",
+			reject: "set by trajector",
+		},
+		{
+			// stdin ends before the question, so nothing was answered,
+			// nothing recorded: status still recommends.
+			name:  "left off with no answer recorded",
+			stdin: "yes\n",
+			want: "One optional setting is off: " + optionalKey + ". Turning it on costs " +
+				"you nothing and makes your records more complete. Run `trajector enable` " +
+				"to see what it changes.",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newEnv(t)
+			e.startProxy()
+			if tc.seed != nil {
+				tc.seed(t, e)
+			}
+			e.stdin = tc.stdin
+			if err := e.machine().Enable(e.project, e.io()); err != nil {
+				t.Fatalf("enable: %v\nstdout: %s", err, e.stdout)
+			}
+			e.stdout.Reset()
+			out := e.statusOutput()
+
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("status = %q, want it to contain %q", out, tc.want)
+			}
+			if tc.reject != "" && strings.Contains(out, tc.reject) {
+				t.Errorf("status = %q, want no %q", out, tc.reject)
+			}
+		})
+	}
+}
+
+func TestStatusShowsNoOptionalSettingLineForAProjectNotEnabled(t *testing.T) {
+	e := newEnv(t)
+	out := e.statusOutput()
+
+	for _, unwanted := range []string{"Optional settings", "optional setting", optionalKey} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("status = %q, want no %q for a project that is not enabled", out, unwanted)
+		}
+	}
+}
+
 func TestStatusReportsAHealthzCopyingPortHolder(t *testing.T) {
 	e := newEnv(t)
 	im := e.occupyPortWithHealthzCopy()

--- a/internal/report/dashboard.go
+++ b/internal/report/dashboard.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/PublicAI01/trajector-cli/internal/capture"
+	"github.com/PublicAI01/trajector-cli/internal/claudesettings"
 	"github.com/PublicAI01/trajector-cli/internal/platform"
 	"github.com/PublicAI01/trajector-cli/internal/proxylife"
 )
@@ -42,6 +43,9 @@ func Dashboard(w io.Writer, d Diagnosis) {
 		}
 		if st.UpstreamMoved.Happened() {
 			fmt.Fprintf(w, "  The upstream moved from %s at %s (base-URL configuration change).\n", st.UpstreamMoved.From, st.UpstreamMoved.At)
+		}
+		for _, line := range optionalSettingLines(d.OptionalSettings) {
+			fmt.Fprintf(w, "  %s\n", line)
 		}
 	case !st.Enabled && !st.Injected():
 		fmt.Fprintln(w, "  Not enabled. Run `trajector enable` to contribute from this project.")
@@ -130,4 +134,35 @@ func Dashboard(w io.Writer, d Diagnosis) {
 		fmt.Fprintln(w, "\nService")
 		fmt.Fprintf(w, "  Notice from the service: %s\n", d.Handshake.Notice)
 	}
+}
+
+// optionalSettingLines closes the Project section with the optional
+// settings. A setting that is on is stated as on; a declined one keeps
+// its single factual line and is never argued with again; only a
+// setting that is off and was never declined gets the recommendation.
+func optionalSettingLines(settings []OptionalSettingStatus) []string {
+	var lines []string
+	declined := 0
+	var off []string
+	for _, s := range settings {
+		switch {
+		case s.State == claudesettings.OnByUs:
+			lines = append(lines, fmt.Sprintf("Optional settings: %s on (set by trajector).", s.Key))
+		case s.State == claudesettings.OnByUser:
+			lines = append(lines, fmt.Sprintf("Optional settings: %s on.", s.Key))
+		case s.Declined:
+			declined++
+		default:
+			off = append(off, s.Key)
+		}
+	}
+	if declined > 0 {
+		lines = append(lines, fmt.Sprintf("Optional settings: %d declined. Run `trajector enable` to review.", declined))
+	}
+	for _, key := range off {
+		lines = append(lines, fmt.Sprintf("One optional setting is off: %s. "+
+			"Turning it on costs you nothing and makes your records more complete. "+
+			"Run `trajector enable` to see what it changes.", key))
+	}
+	return lines
 }

--- a/internal/report/dashboard_test.go
+++ b/internal/report/dashboard_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/PublicAI01/trajector-cli/internal/apiproxy"
+	"github.com/PublicAI01/trajector-cli/internal/claudesettings"
 	"github.com/PublicAI01/trajector-cli/internal/proxylife"
 	"github.com/PublicAI01/trajector-cli/internal/report"
 	"github.com/PublicAI01/trajector-cli/internal/routing"
@@ -187,6 +188,74 @@ func TestStatusPrintsEveryStandingWithTheServicesWordsBetween(t *testing.T) {
 	if explain, says := strings.Index(out, d.Standings[0].Explain()), strings.Index(out, "The service says:"); explain > says {
 		t.Errorf("status = %q, want the standing's own sentence before the service's words", out)
 	}
+}
+
+// The Project section of a contributing project ends with the optional
+// settings. Three of the lines are finalized wording; the fourth — a
+// true of the user's own — is the same statement without the
+// set-by-trajector mark.
+func TestStatusEndsTheProjectSectionWithTheOptionalSetting(t *testing.T) {
+	const key = claudesettings.KeyShowThinkingSummaries
+	recommendation := "One optional setting is off: " + key + ". " +
+		"Turning it on costs you nothing and makes your records more complete. " +
+		"Run `trajector enable` to see what it changes."
+	for _, tc := range []struct {
+		name    string
+		setting report.OptionalSettingStatus
+		want    string
+		reject  []string
+	}{
+		{
+			name:    "off and never decided",
+			setting: report.OptionalSettingStatus{Key: key, State: claudesettings.Unset},
+			want:    recommendation,
+			reject:  []string{"declined", "set by trajector"},
+		},
+		{
+			name:    "explicitly off but never declined here",
+			setting: report.OptionalSettingStatus{Key: key, State: claudesettings.OffByUser},
+			want:    recommendation,
+			reject:  []string{"declined", "set by trajector"},
+		},
+		{
+			name:    "declined",
+			setting: report.OptionalSettingStatus{Key: key, State: claudesettings.Unset, Declined: true},
+			want:    "Optional settings: 1 declined. Run `trajector enable` to review.",
+			reject:  []string{"costs you nothing", "set by trajector"},
+		},
+		{
+			name:    "on because trajector wrote it",
+			setting: report.OptionalSettingStatus{Key: key, State: claudesettings.OnByUs},
+			want:    "Optional settings: " + key + " on (set by trajector).",
+			reject:  []string{"costs you nothing", "declined"},
+		},
+		{
+			name:    "on as the user's own choice",
+			setting: report.OptionalSettingStatus{Key: key, State: claudesettings.OnByUser},
+			want:    "Optional settings: " + key + " on.",
+			reject:  []string{"costs you nothing", "declined", "set by trajector"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := device()
+			d.Project = contributing()
+			d.OptionalSettings = []report.OptionalSettingStatus{tc.setting}
+			out := dashboard(d)
+
+			wants(t, "status", out, tc.want)
+			rejects(t, "status", out, tc.reject...)
+		})
+	}
+}
+
+func TestStatusShowsNoOptionalSettingLineOutsideAContributingProject(t *testing.T) {
+	d := device()
+	d.OptionalSettings = []report.OptionalSettingStatus{
+		{Key: claudesettings.KeyShowThinkingSummaries, State: claudesettings.Unset},
+	}
+	out := dashboard(d)
+
+	rejects(t, "status", out, "optional setting", "Optional settings", claudesettings.KeyShowThinkingSummaries)
 }
 
 // contributing is a project in the fully healthy enabled state.

--- a/internal/report/doctor_test.go
+++ b/internal/report/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/PublicAI01/trajector-cli/internal/claudesettings"
 	"github.com/PublicAI01/trajector-cli/internal/report"
 	"github.com/PublicAI01/trajector-cli/internal/routing"
 	"github.com/PublicAI01/trajector-cli/internal/upload"
@@ -33,6 +34,25 @@ func TestDoctorReportsAnUnreadableTokenStore(t *testing.T) {
 		t.Error("doctor found no problem with an unreadable token store")
 	}
 	wants(t, "doctor", out, "token store could not be read", "Pairing state is unknown")
+}
+
+// An optional setting left off is not a fault, so doctor never
+// mentions one, whatever state it is in.
+func TestDoctorSaysNothingAboutOptionalSettings(t *testing.T) {
+	for _, state := range []claudesettings.SettingState{
+		claudesettings.Unset, claudesettings.OnByUs, claudesettings.OnByUser, claudesettings.OffByUser,
+	} {
+		for _, declined := range []bool{false, true} {
+			d := device()
+			d.Project = contributing()
+			d.OptionalSettings = []report.OptionalSettingStatus{
+				{Key: claudesettings.KeyShowThinkingSummaries, State: state, Declined: declined},
+			}
+			_, out := doctorText(d)
+
+			rejects(t, "doctor", out, "optional", "Optional", claudesettings.KeyShowThinkingSummaries)
+		}
+	}
 }
 
 func TestDoctorListsRejectedBatches(t *testing.T) {

--- a/internal/report/project.go
+++ b/internal/report/project.go
@@ -6,6 +6,17 @@ import (
 	"github.com/PublicAI01/trajector-cli/internal/routing"
 )
 
+// OptionalSettingStatus is one optional Claude Code setting as status
+// presents it: its key, its classified state, and whether the user
+// declined it. Declined rides beside the state because a declined
+// setting is still off — the two together decide whether status
+// recommends or merely records.
+type OptionalSettingStatus struct {
+	Key      string
+	State    claudesettings.SettingState
+	Declined bool
+}
+
 // ProjectStatus is everything the machine knows about one project's
 // consent, resolved in one read. It is the machine's read half: the
 // write methods change this state, a doctor surface prints it, and

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -54,6 +54,11 @@ type Diagnosis struct {
 	// surface leads with and the version gates are judged against.
 	Version string
 	Project ProjectStatus
+	// OptionalSettings is each optional Claude Code setting's state for
+	// the current project, resolved only while it contributes. status
+	// renders it and doctor never does: an optional setting left off is
+	// not a fault.
+	OptionalSettings []OptionalSettingStatus
 	// Proxy is who holds the proxy port, read without the startup grace
 	// only callers about to act on it pay.
 	Proxy    proxylife.Verdict

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -9,7 +9,7 @@ CORE_MIN=85
 # upload, consent lifecycle, and what the surfaces render) are added here
 # as they land. A package joins once its own tests hold it above the
 # floor without a knob that exists only for the tests.
-CORE_PACKAGES="internal/apiproxy internal/capture internal/envelope internal/routing internal/spool internal/lifecycle internal/redact internal/report internal/upload"
+CORE_PACKAGES="internal/apiproxy internal/capture internal/claudesettings internal/envelope internal/routing internal/spool internal/lifecycle internal/redact internal/report internal/upload"
 
 go test -race -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
 


### PR DESCRIPTION
## Summary

`trajector enable` can now offer one optional Claude Code setting — `showThinkingSummaries` — and writes it only on an explicit, fully-disclosed yes. Everything trajector writes this way is recorded with its pre-write state and restored exactly on `disable`/`uninstall`. The rule this follows is published in `PRIVACY.md`.

## What changes

- **The ask.** After the data agreement and before injection, `enable` shows one disclosure screen: which key changes and to what, what it does for you, what it does for us, that it costs nothing (reasoning is generated and billed either way), that it reaches this project only, how to undo it, and that declining changes nothing else. The suggested answer is yes — unless the user explicitly turned the setting off elsewhere, in which case the suggestion flips to no and the screen names the settings layer the `false` came from. A value the user set themselves is stated, left alone, and never recorded. Without an interactive session, nothing is asked and nothing is written.
- **The undo.** Accepting writes the project-local `settings.local.json` top-level key and records the pre-write state (absent / explicit `false`) in the consent store — record first, write second, so no write can exist without the record that undoes it. `disable`, `uninstall`, and doctor's stale-injection repair restore the key to exactly that state, unless the user edited it since: the later edit always wins. A failed restore keeps the record so a rerun can retry. Declining is recorded once and ends the asking; rerunning `enable` is how the user changes their mind.
- **The surfaces.** `status` closes the project section with the setting's state (recommendation / one declined line / on, attributed to trajector or to the user). `doctor` says nothing about it: an optional setting left off is not a fault.
- **The rule.** `PRIVACY.md` gains "Settings we ask you to change": the six conditions a setting must meet before trajector may ask, the two structural limits on asking (never blocking; one refusal ends it), the six disclosures owed every time, and the conditions under which `enable` may write at all.
- **The agreement.** A new clause covers these writes and their exact undo; the version bump pauses recording for existing users until they reconfirm with `enable`. Forwarding is untouched.

## Testing

- Machine-seam tests cover every state of the ask, both prompt defaults, decline-and-rerun, the restore decision table (absent → deleted, `false` → restored, hand-edit → untouched), restore failure keeping the record, non-interactive runs writing nothing, uninstall across roots, and status/doctor rendering.
- `internal/claudesettings` joins the coverage gate's core list; all floors pass (repo 89.0%).
- `go build` / `go vet` / `gofmt` / full test suite / vocabulary check all green.


## Also in this PR

- **CI: one run per pull-request push.** Triggering on every branch push and on `pull_request` ran the same commit twice, and the shared concurrency group cancelled one twin — leaving a failed run on every push to this PR. Push now triggers on `main` only; branch verification without a pull request is available via `workflow_dispatch`.
- **README status line trued up**: "early development, not yet functional" no longer described the binary; it now reads beta, functional end to end, with interfaces and the data agreement still subject to change before 1.0.
- **0.2.1 changelog** for everything above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
